### PR TITLE
Implementing the conclave user profile endpoint as part of SCAT-1847

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -24,7 +24,8 @@
     "access_granttype": "authorization_code",
     "token_validation_endpoint": "/security/tokens/validation",
     "logout": "/security/log-out",
-    "logout_callback": "/logout"
+    "logout_callback": "/logout",
+    "user_profile_endpoint": "/user-profiles"
   },
   "logger":{
     "baseURL": "https://api.logit.io/v2"

--- a/config/production.json
+++ b/config/production.json
@@ -24,7 +24,8 @@
       "access_granttype": "authorization_code",
       "token_validation_endpoint": "/security/tokens/validation",
       "logout": "/security/log-out",
-      "logout_callback": "/logout"
+      "logout_callback": "/logout",
+      "user_profile_endpoint": "/user-profiles"
     },
     "logger":{
       "baseURL": "https://api.logit.io/v2"

--- a/src/main/common/middlewares/oauthservice/authstatecheck.ts
+++ b/src/main/common/middlewares/oauthservice/authstatecheck.ts
@@ -19,72 +19,75 @@ export const AUTH: express.Handler = (req: express.Request, res: express.Respons
     if (SESSION_ID === undefined) {
         res.redirect('/oauth/login');
     }
-    else{
-    let access_token = SESSION_ID;
-    let AuthCheck_Instance = Oauth_Instance.TokenCheckInstance(access_token);
-    let check_token_validation = AuthCheck_Instance.post('');
-    check_token_validation.then(async (data) => {
-        let auth_status_check = data?.data;
-        if (auth_status_check) {
+    else {
+        let access_token = SESSION_ID;
+        let AuthCheck_Instance = Oauth_Instance.TokenCheckInstance(access_token);
+        let check_token_validation = AuthCheck_Instance.post('');
+        check_token_validation.then(async (data) => {
+            let auth_status_check = data?.data;
+            if (auth_status_check) {
 
-            var isAuthicated = {
-                session: req.session['isAuthenticated']
-            }
-            res.locals.Session = isAuthicated
-            // get the decoded payload ignoring signature, no secretOrPrivateKey needed
-            let decoded: any = jwt.decode(access_token, { complete: true });
-            let rolesOfUser = decoded?.payload?.roles
-            let isAuthorized = rolesOfUser?.includes('CAT_USER');
+                var isAuthicated = {
+                    session: req.session['isAuthenticated']
+                }
+                res.locals.Session = isAuthicated
+                // get the decoded payload ignoring signature, no secretOrPrivateKey needed
+                let decoded: any = jwt.decode(access_token, { complete: true });
+                let rolesOfUser = decoded?.payload?.roles
+                let isAuthorized = rolesOfUser?.includes('CAT_USER');
 
-            if(req.session?.user === undefined){
+                if (req.session?.user === undefined) {
+                    res.clearCookie(cookies.sessionID);
+                    res.clearCookie(cookies.state);
+                    res.redirect('/oauth/logout')
+                }
+                else {
+                    if (!isAuthorized) {
+                        res.redirect('/401')
+                    }
+                    else {
+                        let user_email = decoded.payload.sub;
+                        let UserProfile_Instance = Oauth_Instance.TokenWithApiKeyInstance(process.env.CONCLAVE_WRAPPER_API_KEY,user_email);
+                        let userProfile = await UserProfile_Instance.get('');
+                        res.locals.user_firstName = userProfile.data['firstName']
+                        res.locals.user_email = user_email;
+                        let redis_access_token = req.session['access_token'];
+                        if (redis_access_token === access_token) {
+                            var sessionExtendedTime: Date = new Date();
+                            sessionExtendedTime.setMinutes(sessionExtendedTime.getMinutes() + Number(config.get('Session.time')));
+                            req.session.cookie.expires = sessionExtendedTime;
+                            next();
+                        }
+                        else {
+                            res.clearCookie(cookies.sessionID);
+                            res.clearCookie(cookies.state);
+                            res.redirect('/oauth/logout')
+                        }
+                    }
+                }
+            } else {
                 res.clearCookie(cookies.sessionID);
                 res.clearCookie(cookies.state);
                 res.redirect('/oauth/logout')
             }
-            else{
-                        if (!isAuthorized) {
-                            res.redirect('/401')
-                        }
-                        else {
-                            let user_email = decoded.payload.sub;
-                            res.locals.user_email = user_email;
-                            let redis_access_token = req.session['access_token'];
-                                    if (redis_access_token === access_token) {
-                                        var sessionExtendedTime: Date = new Date();
-                                        sessionExtendedTime.setMinutes(sessionExtendedTime.getMinutes() + Number(config.get('Session.time')));
-                                        req.session.cookie.expires = sessionExtendedTime;
-                                        next();
-                                    }
-                                    else {
-                                        res.clearCookie(cookies.sessionID);
-                                        res.clearCookie(cookies.state);
-                                        res.redirect('/oauth/logout')
-                                    }
-                        }
-        }
-        } else {
-            res.clearCookie(cookies.sessionID);
-            res.clearCookie(cookies.state);
-            res.redirect('/oauth/logout')
-        }
-    }).catch(error => {
-        delete error?.config?.['headers'];
-        let Logmessage = {
-            "Person_email": TokenDecoder.decoder(SESSION_ID),
-            "error_location": `${req.headers.host}${req.originalUrl}`,
-            "sessionId": state,
-            "error_reason": "Agreement Service Api cannot be connected",
-            "exception": error
-        }
-        let Log = new LogMessageFormatter(
-            Logmessage.Person_email,
-            Logmessage.error_location,
-            Logmessage.sessionId,
-            Logmessage.error_reason,
-            Logmessage.exception
-        )
-        LoggTracer.errorTracer(Log, res);
-    })
+        }).catch(error => {
+            delete error?.config?.['headers'];
+            let Logmessage = {
+                "Person_email": TokenDecoder.decoder(SESSION_ID),
+                "error_location": `${req.headers.host}${req.originalUrl}`,
+                "sessionId": state,
+                "error_reason": "Agreement Service Api cannot be connected",
+                "exception": error
+            }
+            let Log = new LogMessageFormatter(
+                Logmessage.Person_email,
+                Logmessage.error_location,
+                Logmessage.sessionId,
+                Logmessage.error_reason,
+                Logmessage.exception
+            )
+            LoggTracer.errorTracer(Log, res);
+        })
 
-}
+    }
 }

--- a/src/main/common/util/fetch/OauthService/OauthInstance.ts
+++ b/src/main/common/util/fetch/OauthService/OauthInstance.ts
@@ -11,6 +11,7 @@ export class Oauth_Instance {
 
     static AuthService_BaseURl = process.env.AUTH_SERVER_BASE_URL;
     static tokenCheck_AuthService_BaseURL = process.env.AUTH_SERVER_BASE_URL+ config.get('authenticationService.token_validation_endpoint');
+    static userProfile_AuthService_BaseURL = process.env.AUTH_SERVER_BASE_URL+ config.get('authenticationService.user_profile_endpoint');
     static Client_id = process.env.AUTH_SERVER_CLIENT_ID;
     static Instance = axios.default.create({
         baseURL: Oauth_Instance.AuthService_BaseURl,
@@ -18,6 +19,7 @@ export class Oauth_Instance {
         'Content-Type': 'application/x-www-form-urlencoded'
         }
     })
+    
     static TokenCheckInstance =  (secret_token: string) : axios.AxiosInstance  => {
         let BaseURL : string = `${Oauth_Instance.tokenCheck_AuthService_BaseURL}?client-id=${Oauth_Instance.Client_id}`;
         return  axios.default.create({
@@ -29,4 +31,15 @@ export class Oauth_Instance {
         })
     } 
    
+    // Added this instence to get the user-profile from concalve
+    static TokenWithApiKeyInstance =  (api_key: string, emailid: string) : axios.AxiosInstance  => {
+        let BaseURL : string = `${Oauth_Instance.userProfile_AuthService_BaseURL}?user-id=${emailid}`;
+        return  axios.default.create({
+            baseURL: BaseURL,
+            headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': `${api_key}`   
+            }
+        })
+    } 
 }

--- a/src/main/features/dashboard/views/dashboard.njk
+++ b/src/main/features/dashboard/views/dashboard.njk
@@ -2,8 +2,7 @@
 
 {% from "components/support/macro.njk" import howToGetSupport %}
 
-{% set title = 'home | Contract a Thing' %}
-{# {% set heading = t('Welcome to the Money Claim legal rep beta') %} #}
+{% set title = 'Welcome to the Contract a Thing beta' %}
 {% block content %}
 {{ CCSBreadcrumbs({
         items: data.breadCrumbs
@@ -19,7 +18,7 @@
       <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
         <div class="ccs-page-section">
           <h3 class="govuk-heading-m">
-            Hello, {{ user_email }}
+            Hello, {{ user_firstName }}
           </h3>
           <p class="govuk-body">{{ data.line1 }}</p>
           <h2 class="govuk-heading-m">Get started</h2>

--- a/src/main/features/procurement/controller/procurement.ts
+++ b/src/main/features/procurement/controller/procurement.ts
@@ -19,13 +19,11 @@ import { LoggTracer } from '../../../common/logtracer/tracer';
 export const PROCUREMENT = async (req: express.Request, res: express.Response) => {
   const { lotId, agreementLotName} = req.query;
 
-  console.log({lotId})
   var { SESSION_ID } = req.cookies;
   const agreementId_session = req.session.agreement_id;
   const lotsURL = `/tenders/projects/agreements`;
   const eventTypesURL = `agreements/${agreementId_session}/lots/${lotId}/event-types`;
   let appendData: any = { ...data, SESSION_ID };
-  //agreement_header: { number: agreementId_session } 
   try {
     const { data: typesRaw } = await AgreementAPI.Instance.get(eventTypesURL);
     const types = typesRaw.map((typeRaw: any) => typeRaw.type);


### PR DESCRIPTION
### JIRA link

https://crowncommercialservice.atlassian.net/browse/SCAT-1847

### Change description

Get the login user name and display it in dashboard. Temp dashboard has been created via SCAT-1797: RFI start page :  I need to have a link in the dashboard to start my RFI journey.CLOSED. As part of this task we need to get the user details from the conclave and display it in dashboard.

To get org profile : https://tst.api.crowncommercial.gov.uk/organisation-profiles/556891633619851603

To get an user profile : https://tst.api.crowncommercial.gov.uk/user-profiles?user-id=prathap.mathiyalagan@cognizant.com

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Check and send page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
