### PR TITLE
fixed clear btn functionality in Term and acronyms page.

### DIFF
--- a/src/main/public/assets/scripts/validations/rfi_acronyms.js
+++ b/src/main/public/assets/scripts/validations/rfi_acronyms.js
@@ -93,7 +93,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         document.getElementById('rfi_term_' + target).value = "";
         document.getElementById('rfi_term_definition_' + target).value = "";
-        with_value_count--;
       });
     });
 
@@ -146,7 +145,6 @@ const removeErrorFields = () => {
   $('.govuk-error-message').remove();
   $('.govuk-form-group--error').removeClass('govuk-form-group--error')
   $('.govuk-error-summary').remove();
-
   $(".govuk-input").removeClass("govuk-input--error")
 
 }


### PR DESCRIPTION
### JIRA link



### Change description
The first field close button was stopping the "create another term..." button from creating a new field. It should work now.


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Check and send page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No
