### PR TITLE
SCAT-3429 - added Google Analytics env variables to Terraform iac code

### DIFF
--- a/iac/modules/cat-buyer-ui/main.tf
+++ b/iac/modules/cat-buyer-ui/main.tf
@@ -72,6 +72,14 @@ data "aws_ssm_parameter" "conclave_wrapper_api_key" {
   name = "/cat/${var.environment}/conclave-wrapper-api-key"
 }
 
+data "aws_ssm_parameter" "google_tag_manager_id" {
+  name = "/cat/${var.environment}/google-tag-manager-id"
+}
+
+data "aws_ssm_parameter" "google_site_tag_id" {
+  name = "/cat/${var.environment}/google-site-tag-id"
+}
+
 resource "cloudfoundry_app" "cat_buyer_ui" {
   annotations = {}
   buildpack   = var.buildpack
@@ -88,6 +96,8 @@ resource "cloudfoundry_app" "cat_buyer_ui" {
     SESSION_SECRET : data.aws_ssm_parameter.env_session_secret.value
     CONCLAVE_WRAPPER_API_BASE_URL : data.aws_ssm_parameter.conclave_wrapper_api_base_url.value
     CONCLAVE_WRAPPER_API_KEY : data.aws_ssm_parameter.conclave_wrapper_api_key.value
+    GOOGLE_TAG_MANAGER_ID : data.aws_ssm_parameter.google_tag_manager_id.value
+    GOOGLE_SITE_TAG_ID : data.aws_ssm_parameter.google_site_tag_id.value
   }
   health_check_timeout = var.healthcheck_timeout
   health_check_type    = "port"


### PR DESCRIPTION
### JIRA link

SCAT-3429

### Change description

Injected Google Analytics environment variables from Terraform code into Buyer UI service. 

Variables have been setup in AWS for DEV/INT/UAT

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Check and send page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
