### PR TITLE
fix: some links in response date has to be hidden when js disabled

### DIFF
--- a/src/main/features/rfi/views/response-date.njk
+++ b/src/main/features/rfi/views/response-date.njk
@@ -81,7 +81,7 @@
                 {%if (requirement.OCDS.id !== "Question 1")%}
 
                     <a href="#rfi_clarification_date_expanded_{{loop.index}}" id="change_clarification_date_{{loop.index}}"
-                        class="govuk-link govuk-link--no-visited-state change">change</a>
+                        class="govuk-link govuk-link--no-visited-state change" hidden>change</a>
                 </div>
 
                 <div id="rfi_clarification_date_expanded_{{loop.index}}">
@@ -89,7 +89,7 @@
                         <label class="govuk-label govuk-body"><strong id="lbl-clarification_copy">{{
                                 clarification_date_string }}</strong></label>
                         <br> <a href="#rfi_clarification_date_{{loop.index}}"  id="cancel_change_clarification_date_{{loop.index}}"
-                            class="govuk-link govuk-link--no-visited-state ">I do not want to change this date and time</a>
+                            class="govuk-link govuk-link--no-visited-state " hidden>I do not want to change this date and time</a>
                     </div>
                     <br>
                     <form action="/rfi/add/response-date" method="post" class="ccs_rfi_response_date_form" id="ccs_rfi_response_date_form">

--- a/src/main/public/assets/scripts/validations/rfi_responsedate.js
+++ b/src/main/public/assets/scripts/validations/rfi_responsedate.js
@@ -13,7 +13,11 @@ for(const selector of totalElementSelectors){
 
 for(const selector of totalElementSelectors){
     let elementID = "#change_clarification_date_"+selector;
-    let elementSelector = $(elementID);    
+    let elementCancelID = "#cancel_change_clarification_date_"+selector;
+    let elementSelector = $(elementID);
+    let elementSelectorCancel = $(elementCancelID);
+    elementSelector.fadeIn();  
+    elementSelectorCancel.fadeIn();  
     elementSelector.on('click', ()=> {
         localStorage.removeItem('dateItem');
         localStorage.setItem('dateItem', elementSelector.selector);


### PR DESCRIPTION
### JIRA link
SCAT-3325

### Change description
Some links in response date has to be hidden when js disabled


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Check and send page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
