### PR TITLE
SCAT-3813 - added ROLLBAR_ACCESS_TOKEN environment variable

### DIFF
--- a/iac/modules/cat-buyer-ui/main.tf
+++ b/iac/modules/cat-buyer-ui/main.tf
@@ -80,6 +80,10 @@ data "aws_ssm_parameter" "google_site_tag_id" {
   name = "/cat/${var.environment}/google-site-tag-id"
 }
 
+data "aws_ssm_parameter" "rollbar_access_token" {
+  name = "/cat/${var.environment}/rollbar-access-token"
+}
+
 resource "cloudfoundry_app" "cat_buyer_ui" {
   annotations = {}
   buildpack   = var.buildpack
@@ -99,6 +103,7 @@ resource "cloudfoundry_app" "cat_buyer_ui" {
     GOOGLE_TAG_MANAGER_ID : data.aws_ssm_parameter.google_tag_manager_id.value
     GOOGLE_SITE_TAG_ID : data.aws_ssm_parameter.google_site_tag_id.value
     ROLLBAR_HOST : var.environment
+    ROLLBAR_ACCESS_TOKEN : data.aws_ssm_parameter.rollbar_access_token.value
   }
   health_check_timeout = var.healthcheck_timeout
   health_check_type    = "port"


### PR DESCRIPTION
### JIRA link

SCAT-3813

### Change description

New AWS System Parameter added to SBX1, SBX2, DEV, INT, UAT, NFT environments = `/cat/sbx1/rollbar-access-token`

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
