### PR TITLE
Fix an issue to make sure we check for running deployments at the right point

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,7 @@ before_install:
 script:
   - echo "Run npm test when tests have been fixed"
 
-before_deploy:
-  - echo "Building the frontent assets"
-  - npm run build-assets
-  - rm -rf node_modules/
+after_success:
   - echo "Determine deployment environment"
   - |
     case $TRAVIS_BRANCH in
@@ -57,6 +54,11 @@ before_deploy:
     else
       echo "Checking for a Sandbox deployment"
     fi
+
+before_deploy:
+  - echo "Building the frontent assets"
+  - npm run build-assets
+  - rm -rf node_modules/
 
 deploy:
   - edge: true


### PR DESCRIPTION
### JIRA link

[CAS-1263](https://crowncommercialservice.atlassian.net/browse/CAS-1263)

### Change description

Fix an issue to make sure we are determining the environment before we get to the deployment stage.

I had mistakenly put code to determine if a deployment was necessary in a section that would only run if a deployment is necessary. Now, this will happen after the script section before any deployments are attempted.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


[CAS-1263]: https://crowncommercialservice.atlassian.net/browse/CAS-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ