### PR TITLE
Relax the NPM version requirements to >= v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   — 16.13.1
 
 before_install:
-  - npm i -g npm@9.6.5
+  - npm i -g npm@8.19.4
 
 script:
   - echo "Run npm test when tests have been fixed"

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,7 @@
             },
             "engines": {
                 "node": ">=16.13.1",
-                "npm": ">= 9.6.0"
+                "npm": ">= 8.19.4"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "engines": {
         "node": ">=16.13.1",
-        "npm": ">= 9.6.0"
+        "npm": ">= 8.19.4"
     },
     "scripts": {
         "start": "ts-node -r tsconfig-paths/register src/main/server.ts",


### PR DESCRIPTION
### JIRA link
N/A


### Change description

Relax the NPM version requirements to the latest version for the major version 8. This is so dependabot can work as this uses an older version of NPM. Importantly, this will continue to keep the lock file as version 3 and should prevent major and unexpected changes to the lock file.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
