### PR TITLE
Upgrade the node version to the latest for v18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-dist: bionic
+dist: focal
 os: linux
 language: node_js
 node_js:
-  — 16.13.1
+  — 18.16.0
 
 before_install:
   - npm i -g npm@8.19.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@types/glob": "^7.2.0",
                 "@types/helmet": "^0.0.48",
                 "@types/jsonwebtoken": "^8.5.5",
-                "@types/node": "^17.0.10",
+                "@types/node": "^18.16.0",
                 "@types/nunjucks": "^3.2.1",
                 "@types/redis": "^2.8.32",
                 "@types/require-directory": "^2.1.2",
@@ -119,7 +119,7 @@
                 "typescript": "^4.5.2"
             },
             "engines": {
-                "node": ">=16.13.1",
+                "node": ">= 18.16.0",
                 "npm": ">= 8.19.4"
             }
         },
@@ -2662,9 +2662,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "17.0.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
-            "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog=="
+            "version": "18.16.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
+            "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "private": true,
     "engines": {
-        "node": ">=16.13.1",
+        "node": ">= 18.16.0",
         "npm": ">= 8.19.4"
     },
     "scripts": {
@@ -38,7 +38,7 @@
         "@types/glob": "^7.2.0",
         "@types/helmet": "^0.0.48",
         "@types/jsonwebtoken": "^8.5.5",
-        "@types/node": "^17.0.10",
+        "@types/node": "^18.16.0",
         "@types/nunjucks": "^3.2.1",
         "@types/redis": "^2.8.32",
         "@types/require-directory": "^2.1.2",


### PR DESCRIPTION
### JIRA link

N/A

### Change description

Upgrade the node version to the latest for v18.
It should be noted that we are already using node 18 on the GPaaS so we can confirm that it works.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
