### PR TITLE
Remove `express-nunjucks` and refactor `nunjucks` and `helmet` initialisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
                 "exceljs": "^4.3.0",
                 "express": "^4.18.2",
                 "express-fileupload": "^1.2.1",
-                "express-nunjucks": "^2.2.5",
                 "express-session": "^1.17.2",
                 "form-data": "^4.0.0",
                 "glob": "^10.2.5",
@@ -3658,25 +3657,6 @@
                 "node": "*"
             }
         },
-        "node_modules/assign-deep": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-1.0.1.tgz",
-            "integrity": "sha512-CSXAX79mibneEYfqLT5FEmkqR5WXF+xDRjgQQuVf6wSCXCYU8/vHttPidNar7wJ5BFmKAo8Wei0rCtzb+M/yeA==",
-            "dependencies": {
-                "assign-symbols": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/assign-symbols": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.2.tgz",
-            "integrity": "sha512-9sBQUQZMKFKcO/C3Bo6Rx4CQany0R0UeVcefNGRRdW2vbmaMOhV1sbmlXcQLcD56juLXbSGTBm0GGuvmrAF8pA==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -5087,15 +5067,6 @@
             "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-            "engines": {
-                "iojs": ">= 1.0.0",
-                "node": ">= 0.12.0"
             }
         },
         "node_modules/code-point-at": {
@@ -6558,11 +6529,6 @@
                 "es6-symbol": "^3.1.1"
             }
         },
-        "node_modules/es6-promisify": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.0.tgz",
-            "integrity": "sha512-jCsk2fpfEFusVv1MDkF4Uf0hAzIKNDMgR6LyOIw6a3jwkN1sCgWzuwgnsHY9YSQ8n8P31HoncvE0LC44cpWTrw=="
-        },
         "node_modules/es6-symbol": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
@@ -7276,18 +7242,6 @@
             },
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/express-nunjucks": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/express-nunjucks/-/express-nunjucks-2.2.5.tgz",
-            "integrity": "sha512-91rDyXiIQHBjpdrQoieiq3ehJu5XLFXInE4HeKpY51TVmJftTkGA8eMpfvNs5esA+nLG6PoxmZB3ayiCpNlE+w==",
-            "dependencies": {
-                "assign-deep": "1.0.1",
-                "nunjucks-async-loader": "1.1.5"
-            },
-            "engines": {
-                "node": ">= 8"
             }
         },
         "node_modules/express-session": {
@@ -8213,20 +8167,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-        },
-        "node_modules/fsevents": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-            "deprecated": "\"Please update to latest v2.3 or v2.2\"",
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/fstream": {
             "version": "1.0.12",
@@ -12847,50 +12787,6 @@
                 "chokidar": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/nunjucks-async-loader": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/nunjucks-async-loader/-/nunjucks-async-loader-1.1.5.tgz",
-            "integrity": "sha512-YGnSJgY6hjC3AOn6RJPA87KL5nW0pTz9YeTDeCCl3t6PcM10+wyt6rKgRH4MAPYEIdWaxoHWzaPOzXb9S0LDBQ==",
-            "dependencies": {
-                "chokidar": "3.3.1",
-                "co": "4.6.0",
-                "es6-promisify": "6.1.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/nunjucks-async-loader/node_modules/chokidar": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-            "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
-            "dependencies": {
-                "anymatch": "~3.1.1",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.0",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.3.0"
-            },
-            "engines": {
-                "node": ">= 8.10.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.1.2"
-            }
-        },
-        "node_modules/nunjucks-async-loader/node_modules/readdirp": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-            "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
-            "dependencies": {
-                "picomatch": "^2.0.7"
-            },
-            "engines": {
-                "node": ">=8.10.0"
             }
         },
         "node_modules/nunjucks/node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "exceljs": "^4.3.0",
         "express": "^4.18.2",
         "express-fileupload": "^1.2.1",
-        "express-nunjucks": "^2.2.5",
         "express-session": "^1.17.2",
         "form-data": "^4.0.0",
         "glob": "^10.2.5",

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -2,23 +2,22 @@ const { Express, Logger } = require('@hmcts/nodejs-logging');
 import config = require('config');
 import cookieParser from 'cookie-parser';
 import express from 'express';
-import { Helmet } from './modules/helmet';
+import { initHelmet } from './modules/helmet';
 import * as path from 'path';
 import favicon from 'serve-favicon';
-import { Nunjucks } from './modules/nunjucks';
-import i18next from 'i18next'
+import { initNunjucks } from './modules/nunjucks';
 const env = process.env.NODE_ENV || 'development';
 const developmentMode = env === 'development';
-import { NotFoundError } from './errors/errors'
-import fs from 'fs'
+import { NotFoundError } from './errors/errors';
+import fs from 'fs';
 export const app = express();
-import { glob } from 'glob'
-import { routeExceptionHandler } from './setup/routeexception'
-import { RedisInstanceSetup } from './setup/redis'
-import { fileUploadSetup } from './setup/fileUpload'
-import { CsrfProtection } from './modules/csrf'
-import { URL } from "url";
-import {RequestSecurity} from './setup/requestSecurity'
+import { glob } from 'glob';
+import { routeExceptionHandler } from './setup/routeexception';
+import { RedisInstanceSetup } from './setup/redis';
+import { fileUploadSetup } from './setup/fileUpload';
+import { CsrfProtection } from './modules/csrf';
+import { URL } from 'url';
+import { RequestSecurity } from './setup/requestSecurity';
 
 app.locals.ENV = env;
 
@@ -32,8 +31,8 @@ app.locals.ENV = env;
 /**
  * @env Local variables 
  */
-const checkforenvFile = fs.existsSync('.env')
-import { localEnvariables } from './setup/envs'
+const checkforenvFile = fs.existsSync('.env');
+import { localEnvariables } from './setup/envs';
 if (checkforenvFile) {
   localEnvariables(app);
 }
@@ -46,17 +45,17 @@ fileUploadSetup(app);
 
 const logger = Logger.getLogger('app');
 
-new Nunjucks(developmentMode, i18next).enableFor(app);
+initNunjucks(app, developmentMode);
 // secure the application by adding various HTTP headers to its responses
-new Helmet(config.get('security')).enableFor(app);
+initHelmet(app, config.get('security'));
 
 app.use(Express.accessLogger());
 app.use(favicon(path.join(__dirname, '/public/assets/images/favicon.ico')));
-app.use(express.json({limit: '500mb'}))
-app.use(express.urlencoded({limit: '500mb', extended: true, parameterLimit: 1000000}));
+app.use(express.json({ limit: '500mb' }));
+app.use(express.urlencoded({ limit: '500mb', extended: true, parameterLimit: 1000000 }));
 app.use(cookieParser());
 if (env !== 'mocha') {
-  new CsrfProtection().enableFor(app)
+  new CsrfProtection().enableFor(app);
 }
 
 //Implementation of secure Request Methods 
@@ -70,75 +69,75 @@ app.use((req, res, next) => {
   );
   res.setHeader(
     'Content-Security-Policy',
-    "script-src 'self' 'unsafe-inline' *.googletagmanager.com  https://www.google-analytics.com https://ssl.google-analytics.com https://cdn2.gbqofs.com https://report.crown-comm.gbqofs.com; img-src 'self' *.google-analytics.com *.googletagmanager.com; connect-src 'self' *.google-analytics.com *.analytics.google.com *.googletagmanager.com https://report.crown-comm.gbqofs.io; child-src blob:"
+    'script-src \'self\' \'unsafe-inline\' *.googletagmanager.com  https://www.google-analytics.com https://ssl.google-analytics.com https://cdn2.gbqofs.com https://report.crown-comm.gbqofs.com; img-src \'self\' *.google-analytics.com *.googletagmanager.com; connect-src \'self\' *.google-analytics.com *.analytics.google.com *.googletagmanager.com https://report.crown-comm.gbqofs.io; child-src blob:'
   );
-  if(process.env.LOGIN_DIRECTOR_URL == "NONE") {
+  if (process.env.LOGIN_DIRECTOR_URL == 'NONE') {
     res.locals.LOGIN_DIRECTOR_URL = '/oauth/login';
   } else {
     res.locals.LOGIN_DIRECTOR_URL = process.env.LOGIN_DIRECTOR_URL;
   }
-  
+
   res.locals.GOOGLE_TAG_MANAGER_ID = process.env.GOOGLE_TAG_MANAGER_ID;
   res.locals.GLOBAL_SITE_TAG_ID = process.env.GOOGLE_SITE_TAG_ID;
   res.locals.assetBundlerMode = env.trim();
   switch (process.env.ROLLBAR_HOST) {
-    case 'local': {
-      process.env.ROLLBAR_ENVIRONMENT = 'local';
-      process.env.LOGIT_ENVIRONMENT = 'LOCAL'
-      break;
-    }
-    case 'dev': {
-      process.env.ROLLBAR_ENVIRONMENT = 'development';
-      process.env.LOGIT_ENVIRONMENT = 'DEV';
-      break;
-    }
-    case 'int': {
-      process.env.ROLLBAR_ENVIRONMENT = 'integration';
-      process.env.LOGIT_ENVIRONMENT = 'SIT';
-      break;
-    }
-    case 'uat': {
-      process.env.ROLLBAR_ENVIRONMENT = 'integration';
-      process.env.LOGIT_ENVIRONMENT = 'UAT';
-      break;
-    }
-    case 'nft': {
-      process.env.ROLLBAR_ENVIRONMENT = 'sandbox';
-      process.env.LOGIT_ENVIRONMENT = 'NFT';
-      break;
-    }
-    case 'prd': {
-      process.env.ROLLBAR_ENVIRONMENT = 'production';
-      process.env.LOGIT_ENVIRONMENT = 'PROD';
-      break;
-    }
-    case 'pre': {
-      process.env.ROLLBAR_ENVIRONMENT = 'pre-production';
-      process.env.LOGIT_ENVIRONMENT = 'PRE-PROD';
-      break;
-    }
-    default: {
-      process.env.ROLLBAR_ENVIRONMENT = 'sandbox';
-      process.env.LOGIT_ENVIRONMENT = 'SANDBOX';
-      break;
-    }
+  case 'local': {
+    process.env.ROLLBAR_ENVIRONMENT = 'local';
+    process.env.LOGIT_ENVIRONMENT = 'LOCAL';
+    break;
+  }
+  case 'dev': {
+    process.env.ROLLBAR_ENVIRONMENT = 'development';
+    process.env.LOGIT_ENVIRONMENT = 'DEV';
+    break;
+  }
+  case 'int': {
+    process.env.ROLLBAR_ENVIRONMENT = 'integration';
+    process.env.LOGIT_ENVIRONMENT = 'SIT';
+    break;
+  }
+  case 'uat': {
+    process.env.ROLLBAR_ENVIRONMENT = 'integration';
+    process.env.LOGIT_ENVIRONMENT = 'UAT';
+    break;
+  }
+  case 'nft': {
+    process.env.ROLLBAR_ENVIRONMENT = 'sandbox';
+    process.env.LOGIT_ENVIRONMENT = 'NFT';
+    break;
+  }
+  case 'prd': {
+    process.env.ROLLBAR_ENVIRONMENT = 'production';
+    process.env.LOGIT_ENVIRONMENT = 'PROD';
+    break;
+  }
+  case 'pre': {
+    process.env.ROLLBAR_ENVIRONMENT = 'pre-production';
+    process.env.LOGIT_ENVIRONMENT = 'PRE-PROD';
+    break;
+  }
+  default: {
+    process.env.ROLLBAR_ENVIRONMENT = 'sandbox';
+    process.env.LOGIT_ENVIRONMENT = 'SANDBOX';
+    break;
+  }
   }
 
   // Health check URL values.
   const url = new URL(process.env.CAT_URL);
   process.env.PACKAGES_ENVIRONMENT = url.host;
-  process.env.PACKAGES_NAME = "CCS Scale CAS Buyer UI";
-  process.env.PACKAGES_PROJECT = "cas-buyer-frontend";
+  process.env.PACKAGES_NAME = 'CCS Scale CAS Buyer UI';
+  process.env.PACKAGES_PROJECT = 'cas-buyer-frontend';
   next();
 });
 
-app.enable('trust proxy')
+app.enable('trust proxy');
 
 /**
  * @Routable path getting content from default.json
  */
-const featureRoutes: Array<{path: string}> = config.get('featureDir')
-featureRoutes?.forEach((aRoute: {path: string}) => {
+const featureRoutes: Array<{ path: string }> = config.get('featureDir');
+featureRoutes?.forEach((aRoute: { path: string }) => {
   glob.sync(__dirname + aRoute?.path)
     .map((filename: string) => require(filename))
     .forEach((route: any) => route.default(app));
@@ -154,4 +153,4 @@ routeExceptionHandler(
   NotFoundError,
   logger,
   env
-)
+);

--- a/src/main/modules/helmet/index.ts
+++ b/src/main/modules/helmet/index.ts
@@ -1,49 +1,43 @@
-import * as express from 'express';
-import helmet = require('helmet');
+import { Application } from 'express';
+import helmet from 'helmet';
 
-export interface HelmetConfig {
+interface HelmetConfig {
   referrerPolicy: string;
 }
 
 const googleAnalyticsDomain = '*.google-analytics.com';
 const googleAnalyticsGtm = '*.googletagmanager.com';
-const self = "'self'";
+const self = '\'self\'';
 
-/**
- * Module that enables helmet in the application
- */
-export class Helmet {
-  constructor(public config: HelmetConfig) {}
+const setContentSecurityPolicy = (app: Application): void => {
+  app.use(
+    helmet.contentSecurityPolicy({
+      directives: {
+        connectSrc: [self, googleAnalyticsDomain, 'https://stats.g.doubleclick.net'],
+        defaultSrc: ['\'none\''],
+        fontSrc: [self, 'data:'],
+        imgSrc: [self, googleAnalyticsDomain, googleAnalyticsGtm],
+        objectSrc: [self],
+        scriptSrc: [self,'https://snap.licdn.com', googleAnalyticsDomain, '\'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=\'', '\'sha256-yJD+OaJ97T/y5QHr3Se9W0AW2baOVjc1FR3Na10Ih+Y=\'','\'sha256-Zk3m64g3XkpEOa4ilYFv4J6vnDXIEsOJMYonokV/R6E=\'', '\'sha256-zEF/ALwwDYV2nZ+rdYGh2XpjU1lbO3oZ2osZayOlmpw=\'', googleAnalyticsGtm, '\'sha256-xB3p3jeZFuTiApvSQLM9BrzAfwNP7gzCnJPZ4VRVpCw=\''],
+        styleSrc: [self],
+      },
+    }),
+  );
+};
 
-  public enableFor(app: express.Express): void {
-    // include default helmet functions
-    app.use(helmet());
-
-    this.setContentSecurityPolicy(app);
-    this.setReferrerPolicy(app, this.config.referrerPolicy);
+const setReferrerPolicy = (app: Application, policy: string): void => {
+  if (!policy) {
+    throw new Error('Referrer policy configuration is required');
   }
 
-  private setContentSecurityPolicy(app: express.Express): void {
-    app.use(
-      helmet.contentSecurityPolicy({
-        directives: {
-          connectSrc: [self, googleAnalyticsDomain, 'https://stats.g.doubleclick.net'],
-          defaultSrc: ["'none'"],
-          fontSrc: [self, 'data:'],
-          imgSrc: [self, googleAnalyticsDomain, googleAnalyticsGtm],
-          objectSrc: [self],
-          scriptSrc: [self,'https://snap.licdn.com', googleAnalyticsDomain, "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='", "'sha256-yJD+OaJ97T/y5QHr3Se9W0AW2baOVjc1FR3Na10Ih+Y='","'sha256-Zk3m64g3XkpEOa4ilYFv4J6vnDXIEsOJMYonokV/R6E='", "'sha256-zEF/ALwwDYV2nZ+rdYGh2XpjU1lbO3oZ2osZayOlmpw='", googleAnalyticsGtm, "'sha256-xB3p3jeZFuTiApvSQLM9BrzAfwNP7gzCnJPZ4VRVpCw='"],
-          styleSrc: [self],
-        },
-      }),
-    );
-  }
+  app.use(helmet.referrerPolicy({ policy }));
+};
 
-  private setReferrerPolicy(app: express.Express, policy: string): void {
-    if (!policy) {
-      throw new Error('Referrer policy configuration is required');
-    }
+const initHelmet = (app: Application, config: HelmetConfig): void => {
+  app.use(helmet());
 
-    app.use(helmet.referrerPolicy({ policy }));
-  }
-}
+  setContentSecurityPolicy(app);
+  setReferrerPolicy(app, config.referrerPolicy);
+};
+
+export { initHelmet };


### PR DESCRIPTION
### JIRA link

N/A

### Change description

I have removed express-nunjucks as we do not use it so don’t really need it as a dependency.

In addition, I’ve tidied up how we initialise Nunjucks so that it is more clear what is happening. Any additional changes are caused by VSCode formatting/linting the file when I save.

I’ve also updated the initialisation of Helmet too as just creating a new class instance and not assigning it is a strange thing to do as GC will just clear it up. Therefore, I’ve now made it functional.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
