### PR TITLE
Remove logging of fetched data into the console

### DIFF
--- a/src/main/common/middlewares/agreementservice/agreementdetailsfetch.ts
+++ b/src/main/common/middlewares/agreementservice/agreementdetailsfetch.ts
@@ -1,7 +1,6 @@
-//@ts-nocheck
-import * as express from 'express'
-import { AgreementAPI } from '../../util/fetch/agreementservice/agreementsApiInstance'
-import { LoggTracer } from '../../logtracer/tracer'
+import { Handler, Request, Response, NextFunction } from 'express';
+import { AgreementAPI } from '../../util/fetch/agreementservice/agreementsApiInstance';
+import { LoggTracer } from '../../logtracer/tracer';
 import { TokenDecoder } from '../../tokendecoder/tokendecoder';
 import { Logger } from '@hmcts/nodejs-logging';
 const logger = Logger.getLogger('agreementdetailsfetch');
@@ -14,34 +13,34 @@ const logger = Logger.getLogger('agreementdetailsfetch');
  */
 export class AgreementDetailsFetchMiddleware {
 
-    static FetchAgreements: express.Handler = (req: express.Request, res: express.Response, next: express.NextFunction) => {
-        const { SESSION_ID, state } = req.cookies;
-        const agreementId_session = req.session.agreement_id;
-        if (agreementId_session) {
-            const agreementLotName = req.session.agreementLotName;
-            const lotid = req.session?.lotId;
-            const BaseURL = `agreements/${agreementId_session}`;
-            const retrieveAgreementPromise = AgreementAPI.Instance(null).get(BaseURL);
-            retrieveAgreementPromise.then((data) => {
-                const containedData = data?.data;
-                logger.info("Feached agreement details from Agreement service API")
-                logger.info(data)
-                const project_name = req.session.project_name;
-                const projectId = req.session.projectId;
+  static FetchAgreements: Handler = (req: Request, res: Response, next: NextFunction) => {
+    const { SESSION_ID, state } = req.cookies;
+    const agreementIdSession = req?.session?.agreement_id;
+    if (agreementIdSession) {
+      const agreementLotName = req?.session?.agreementLotName;
+      const lotid = req.session?.lotId;
+      const BaseURL = `agreements/${agreementIdSession}`;
+      const retrieveAgreementPromise = AgreementAPI.Instance(null).get(BaseURL);
+      retrieveAgreementPromise.then((data) => {
+        const containedData = data?.data;
+        logger.info('Feached agreement details from Agreement service API');
+        const projectName = req?.session?.project_name;
+        const projectId = req?.session?.projectId;
 
-                req.session.agreementName = containedData['name'];
-                res.locals.selectedAgreement = containedData
-                const agreementName = req.session?.agreementName;
-                res.locals.agreement_header = { project_name,projectId, agreementName, agreementId_session, agreementLotName, lotid }
-                next();
-            }).catch(
-                (error) => {
-                    LoggTracer.errorLogger(res, error, `${req.headers.host}${req.originalUrl}`, state,
-                        TokenDecoder.decoder(SESSION_ID), "Agreement Service Api cannot be connected", true)
-                }
-            )
-        } else {
-            next();
+        if (req?.session?.agreementName !== undefined) req.session.agreementName = containedData['name'];
+
+        res.locals.selectedAgreement = containedData;
+        const agreementName = req.session?.agreementName;
+        res.locals.agreement_header = { projectName, projectId, agreementName, agreementIdSession, agreementLotName, lotid };
+        next();
+      }).catch(
+        (error) => {
+          LoggTracer.errorLogger(res, error, `${req.headers.host}${req.originalUrl}`, state,
+            TokenDecoder.decoder(SESSION_ID), 'Agreement Service Api cannot be connected', true);
         }
+      );
+    } else {
+      next();
     }
+  };
 }


### PR DESCRIPTION
### JIRA link

N/A

### Change description

Remove logging of the fetch response as it was clogging up the console.

This has come about due to the update due to an update to `@hmcts/nodejs-healthcheck` which updated `@hmcts/nodejs-logging` and this update changed the logging. Where as the previous version was happy to take and ignore non-string messages, this version does log the results (which are quite large) to the console.

As we don’t need to log it (it did not used to do anything), I’ve removed it from the code.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
