### PR TITLE
CAS-1340 - Create service modules to interact with APIs

### DIFF
--- a/config/.env.test
+++ b/config/.env.test
@@ -1,0 +1,14 @@
+NODE_ENV=test
+AUTH_SERVER_BASE_URL=http://auth-server.com
+CONCLAVE_WRAPPER_API_BASE_URL=http://conclave-wrapper.com
+AGREEMENTS_SERVICE_API_URL=http://agreements-service.com
+GCLOUD_SUPPLIER_API_URL=http://g-cloud-supplier.com
+GCLOUD_SEARCH_API_URL=http://g-cloud-search.com
+GCLOUD_SERVICES_API_URL=http://g-cloud-services.com
+CAT_URL=http://cas.com
+AUTH_SERVER_CLIENT_ID=auth-server-client-id
+AUTH_SERVER_CLIENT_SECRET=auth-server-client-secret
+CONCLAVE_WRAPPER_API_KEY=concalve-wrapper-api-key
+GCLOUD_TOKEN=g-cloud-api-key
+GCLOUD_SEARCH_API_TOKEN=g-cloud-search-api-key
+GCLOUD_INDEX=g-cloud-42

--- a/config/test.json
+++ b/config/test.json
@@ -1,0 +1,18 @@
+{
+  "bankholidayservice": {
+    "BASEURL": "https://www.gov.uk"
+  },
+  "contentService": {
+    "BASEURL": "https://webprod-cms.crowncommercial.gov.uk"
+  },
+  "settings": {
+    "fetch-timelimit": "15"
+  },
+  "authenticationService": {
+    "token-endpoint": "/security/token",
+    "refresh_token": "refresh_token",
+    "token_validation_endpoint": "/security/tokens/validation",
+    "logout": "/security/log-out",
+    "logout_callback": "/logout"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
                 "chai-as-promised": "^7.1.1",
                 "chai-http": "^4.3.0",
                 "debug": "^4.1.1",
+                "env-cmd": "^10.1.0",
                 "eslint": "^8.40.0",
                 "eslint-config-prettier": "^8.8.0",
                 "gulp": "^4.0.2",
@@ -104,7 +105,8 @@
                 "sinon-chai": "^3.7.0",
                 "supertest": "^4.0.2",
                 "ts-node-dev": "^2.0.0",
-                "typescript": "^4.5.2"
+                "typescript": "^4.5.2",
+                "undici": "^5.22.1"
             },
             "engines": {
                 "node": "18.16.0",
@@ -6391,6 +6393,31 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/env-cmd": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+            "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+            "dev": true,
+            "dependencies": {
+                "commander": "^4.0.0",
+                "cross-spawn": "^7.0.0"
+            },
+            "bin": {
+                "env-cmd": "bin/env-cmd.js"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/env-cmd/node_modules/commander": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/envinfo": {
@@ -17019,6 +17046,39 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
             "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw==",
             "dev": true
+        },
+        "node_modules/undici": {
+            "version": "5.22.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+            "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+            "dev": true,
+            "dependencies": {
+                "busboy": "^1.6.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
+        "node_modules/undici/node_modules/busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "dev": true,
+            "dependencies": {
+                "streamsearch": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.16.0"
+            }
+        },
+        "node_modules/undici/node_modules/streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            }
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "test": "mocha \"src/test/**/*.test.ts\" --reporter-options reportFilename=all,inlineAssets=true,reportTitle=CAS-buyer-frontend-tests-all",
         "test:a11y": "mocha \"src/test/a11y/**/*.test.ts\" --timeout 60000 --reporter-options reportFilename=a11y,inlineAssets=true,reportTitle=CAS-buyer-frontend-a11y",
         "test:routes": "mocha \"src/test/routes/**/*.test.ts\" --reporter-options reportFilename=routes,inlineAssets=true,reportTitle=CAS-buyer-frontend-routes",
-        "test:unit": "mocha \"src/test/unit/**/*.test.ts\" --reporter-options reportFilename=unit,inlineAssets=true,reportTitle=CAS-buyer-frontend-unit-tests-all",
+        "test:unit": "env-cmd -f config/.env.test mocha \"src/test/unit/**/*.test.ts\" --reporter-options reportFilename=unit,inlineAssets=true,reportTitle=CAS-buyer-frontend-unit-tests-all",
         "test:coverage": "nyc --reporter=html npm test",
         "test:smoke": "echo 'TODO add smoke tests' && exit 1",
         "test:functional": "echo 'TODO add functional tests' && exit 1",
@@ -101,6 +101,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-http": "^4.3.0",
         "debug": "^4.1.1",
+        "env-cmd": "^10.1.0",
         "eslint": "^8.40.0",
         "eslint-config-prettier": "^8.8.0",
         "gulp": "^4.0.2",
@@ -123,6 +124,7 @@
         "sinon-chai": "^3.7.0",
         "supertest": "^4.0.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^4.5.2"
+        "typescript": "^4.5.2",
+        "undici": "^5.22.1"
     }
 }

--- a/src/main/services/agreementsService.ts
+++ b/src/main/services/agreementsService.ts
@@ -1,0 +1,7 @@
+import { agreementsServiceAPI } from './agreementsService/api';
+
+const agreementsService = {
+  api: agreementsServiceAPI
+};
+
+export { agreementsService };

--- a/src/main/services/agreementsService/api.ts
+++ b/src/main/services/agreementsService/api.ts
@@ -1,0 +1,103 @@
+import { LotDetail } from '@common/middlewares/models/lot-detail';
+import { genericFecthGet } from '../helpers/api';
+import { EndPoints, AgreementLotEventType } from '../types/agreementsService/api';
+import { FetchResult } from '../types/helpers/api';
+import { LotSupplier } from '@common/middlewares/models/lot-supplier';
+import { AgreementDetail } from '@common/middlewares/models/agreement-detail';
+
+const baseURL: string = process.env.AGREEMENTS_SERVICE_API_URL;
+
+const headers = {
+  'Content-Type': 'application/json'
+};
+
+const endPoints: EndPoints = {
+  agreement: '/agreements/:agreement-id',
+  agreementLots: '/agreements/:agreement-id/lots',
+  agreementLot: '/agreements/:agreement-id/lots/:lot-id',
+  agreementLotSuppliers: '/agreements/:agreement-id/lots/:lot-id/suppliers',
+  agreementLotEventTypes: '/agreements/:agreement-id/lots/:lot-id/event-types'
+};
+
+// GET /agreements/:agreement-id
+const getAgreement = async (agreementId: string): Promise<FetchResult<AgreementDetail>> => {
+  return genericFecthGet<AgreementDetail>(
+    {
+      baseURL: baseURL,
+      path: endPoints.agreement,
+      params: [
+        [':agreement-id', agreementId]
+      ]
+    },
+    headers
+  );
+};
+
+// GET /agreements/:agreement-id/lots
+const getAgreementLots = async (agreementId: string): Promise<FetchResult<LotDetail[]>> => {
+  return genericFecthGet<LotDetail[]>(
+    {
+      baseURL: baseURL,
+      path: endPoints.agreementLots,
+      params: [
+        [':agreement-id', agreementId]
+      ]
+    },
+    headers
+  );
+};
+
+// GET /agreements/:agreement-id/lots/:lot-id
+const getAgreementLot = async (agreementId: string, lotId: string): Promise<FetchResult<LotDetail>> => {
+  return genericFecthGet<LotDetail>(
+    {
+      baseURL: baseURL,
+      path: endPoints.agreementLot,
+      params: [
+        [':agreement-id', agreementId],
+        [':lot-id', lotId]
+      ]
+    },
+    headers
+  );
+};
+
+// GET /agreements:agreement-id/lots/:lot-id/suppliers
+const getAgreementLotSuppliers = async (agreementId: string, lotId: string): Promise<FetchResult<LotSupplier[]>> => {
+  return genericFecthGet<LotSupplier[]>(
+    {
+      baseURL: baseURL,
+      path: endPoints.agreementLotSuppliers,
+      params: [
+        [':agreement-id', agreementId],
+        [':lot-id', lotId]
+      ]
+    },
+    headers
+  );
+};
+
+// GET /agreements:agreement-id/lots/:lot-id/suppliers
+const getAgreementLotEventTypes = async (agreementId: string, lotId: string): Promise<FetchResult<AgreementLotEventType[]>> => {
+  return genericFecthGet<AgreementLotEventType[]>(
+    {
+      baseURL: baseURL,
+      path: endPoints.agreementLotEventTypes,
+      params: [
+        [':agreement-id', agreementId],
+        [':lot-id', lotId]
+      ]
+    },
+    headers
+  );
+};
+
+const agreementsServiceAPI = {
+  getAgreement,
+  getAgreementLots,
+  getAgreementLot,
+  getAgreementLotSuppliers,
+  getAgreementLotEventTypes
+};
+
+export { agreementsServiceAPI };

--- a/src/main/services/bankHolidays.ts
+++ b/src/main/services/bankHolidays.ts
@@ -1,0 +1,7 @@
+import { bankHolidaysAPI } from './bankHolidays/api';
+
+const bankHolidays = {
+  api: bankHolidaysAPI
+};
+
+export { bankHolidays };

--- a/src/main/services/bankHolidays/api.ts
+++ b/src/main/services/bankHolidays/api.ts
@@ -1,0 +1,29 @@
+import config from 'config';
+import { genericFecthGet } from '../helpers/api';
+import { FetchResult } from '../types/helpers/api';
+import { BankHolidays, EndPoints } from '../types/bankHolidays/api';
+
+const baseURL: string = config.get('bankholidayservice.BASEURL');
+
+const endPoints: EndPoints = {
+  bankHolidays: '/bank-holidays.json',
+};
+
+// GET /bank-holidays.json
+const getBankHolidays = async (): Promise<FetchResult<BankHolidays>> => {
+  return genericFecthGet<BankHolidays>(
+    {
+      baseURL: baseURL,
+      path: endPoints.bankHolidays
+    },
+    {
+      'Content-Type': 'application/json',
+    }
+  );
+};
+
+const bankHolidaysAPI = {
+  getBankHolidays
+};
+
+export { bankHolidaysAPI };

--- a/src/main/services/contentService.ts
+++ b/src/main/services/contentService.ts
@@ -1,0 +1,7 @@
+import { contentServiceAPI } from './contentService/api';
+
+const contentService = {
+  api: contentServiceAPI
+};
+
+export { contentService };

--- a/src/main/services/contentService/api.ts
+++ b/src/main/services/contentService/api.ts
@@ -1,0 +1,34 @@
+import config from 'config';
+import { genericFecthGet } from '../helpers/api';
+import { FetchResult } from '../types/helpers/api';
+import { ContentServiceMenu, EndPoints } from '../types/contentService/api';
+
+const baseURL: string = config.get('contentService.BASEURL');
+const timeout = Number(config.get('settings.fetch-timelimit'));
+
+const endPoints: EndPoints = {
+  menu: '/wp-json/wp-api-menus/v2/menus/:menu-id',
+};
+
+// GET /wp-json/wp-api-menus/v2/menus/:menu-id
+const getMenu = async (menuId: string): Promise<FetchResult<ContentServiceMenu>> => {
+  return genericFecthGet<ContentServiceMenu>(
+    {
+      baseURL: baseURL,
+      path: endPoints.menu,
+      params: [
+        [':menu-id', menuId]
+      ]
+    },
+    {
+      'Content-Type': 'application/json',
+    },
+    timeout
+  );
+};
+
+const contentServiceAPI = {
+  getMenu
+};
+
+export { contentServiceAPI };

--- a/src/main/services/gCloud.ts
+++ b/src/main/services/gCloud.ts
@@ -1,0 +1,13 @@
+import { searchAPI } from './gCloud/search/api';
+import { serviceAPI } from './gCloud/service/api';
+import { supplierAPI } from './gCloud/supplier/api';
+
+const gCloud = {
+  api: {
+    search: searchAPI,
+    service: serviceAPI,
+    supplier: supplierAPI
+  }
+};
+
+export { gCloud };

--- a/src/main/services/gCloud/search/api.ts
+++ b/src/main/services/gCloud/search/api.ts
@@ -1,0 +1,48 @@
+import { genericFecthGet } from 'main/services/helpers/api';
+import { EndPoints, GCloudServiceAggregations, GCloudServiceSearch } from 'main/services/types/gCloud/search/api';
+import { FetchResult } from 'main/services/types/helpers/api';
+
+const baseURL: string = process.env.GCLOUD_SEARCH_API_URL;
+const searchAPIKey = process.env.GCLOUD_SEARCH_API_TOKEN;
+const gCloudIndex = process.env.GCLOUD_INDEX;
+
+const endPoints: EndPoints = {
+  servicesSearch: `${gCloudIndex}/services/search`,
+  servicesAggregations: `${gCloudIndex}/services/aggregations`
+};
+
+const headers = {
+  'Content-Type': 'application/json',
+  Authorization: `Bearer ${searchAPIKey}`
+};
+
+// GET /:g-cloud-index/services/search
+const getServicesSearch = async (queryParams?: { [key: string]: string }): Promise<FetchResult<GCloudServiceSearch>> => {
+  return genericFecthGet<GCloudServiceSearch>(
+    {
+      baseURL: baseURL,
+      path: endPoints.servicesSearch,
+      queryParams: queryParams
+    },
+    headers
+  );
+};
+
+// GET /:g-cloud-index/services/aggregations
+const getServicesAggregations = async (queryParams?: { [key: string]: string }): Promise<FetchResult<GCloudServiceAggregations>> => {
+  return genericFecthGet<GCloudServiceAggregations>(
+    {
+      baseURL: baseURL,
+      path: endPoints.servicesAggregations,
+      queryParams: queryParams
+    },
+    headers
+  );
+};
+
+const searchAPI = {
+  getServicesSearch,
+  getServicesAggregations
+};
+
+export { searchAPI };

--- a/src/main/services/gCloud/service/api.ts
+++ b/src/main/services/gCloud/service/api.ts
@@ -1,0 +1,67 @@
+import { genericFecthGet } from 'main/services/helpers/api';
+import { EndPoints, GCloudService, GCloudSupplier, GCloudSupplierFramework } from 'main/services/types/gCloud/service/api';
+import { FetchResult } from 'main/services/types/helpers/api';
+
+const baseURL: string = process.env.GCLOUD_SERVICES_API_URL;
+const dmpAPIKey = process.env.GCLOUD_TOKEN;
+
+const headers = {
+  'Content-Type': 'application/json',
+  Authorization: `Bearer ${dmpAPIKey}`
+};
+
+const endPoints: EndPoints = {
+  service: '/services/:service-id',
+  supplier: '/suppliers/:supplier-id',
+  supplierFramework: '/suppliers/:supplier-id/frameworks/g-cloud-13'
+};
+
+// GET /services/:service-id
+const getService = async (serviceId: string): Promise<FetchResult<GCloudService>> => {
+  return genericFecthGet<GCloudService>(
+    {
+      baseURL: baseURL,
+      path: endPoints.service,
+      params: [
+        [':service-id', serviceId]
+      ]
+    },
+    headers
+  );
+};
+
+// GET /services/:service-id
+const getSupplier = async (supplierId: string): Promise<FetchResult<GCloudSupplier>> => {
+  return genericFecthGet<GCloudSupplier>(
+    {
+      baseURL: baseURL,
+      path: endPoints.supplier,
+      params: [
+        [':supplier-id', supplierId]
+      ]
+    },
+    headers
+  );
+};
+
+// GET /suppliers/:supplier-id/frameworks/g-cloud-13
+const getSupplierFramework = async (supplierId: string): Promise<FetchResult<GCloudSupplierFramework>> => {
+  return genericFecthGet<GCloudSupplierFramework>(
+    {
+      baseURL: baseURL,
+      path: endPoints.supplierFramework,
+      params: [
+        [':supplier-id', supplierId]
+      ]
+    },
+    headers
+  );
+};
+
+const serviceAPI = {
+  getService,
+  getSupplier,
+  getSupplierFramework
+};
+
+export { serviceAPI };

--- a/src/main/services/gCloud/supplier/api.ts
+++ b/src/main/services/gCloud/supplier/api.ts
@@ -1,0 +1,39 @@
+import { genericFecthGet } from 'main/services/helpers/api';
+import { EndPoints, GCloudFilters, GCloudFilterQueryParams } from 'main/services/types/gCloud/supplier/api';
+import { FetchResult } from 'main/services/types/helpers/api';
+
+const baseURL: string = process.env.GCLOUD_SUPPLIER_API_URL;
+const supplierAPIKey = process.env.GCLOUD_TOKEN;
+
+const endPoints: EndPoints = {
+  filters: '/g-cloud-filters'
+};
+
+// GET /g-cloud-filters
+const getGCloudFilters = async (lot: string, serviceCategories: string, parentCategory: string): Promise<FetchResult<GCloudFilters>> => {
+  const queryParams: GCloudFilterQueryParams = {
+    lot: lot,
+    serviceCategories: serviceCategories,
+    parentCategory: parentCategory
+  };
+
+  Object.keys(queryParams).forEach((key: keyof GCloudFilterQueryParams) => queryParams[key] === undefined && delete queryParams[key]);
+
+  return genericFecthGet<GCloudFilters>(
+    {
+      baseURL: baseURL,
+      path: endPoints.filters,
+      queryParams: queryParams
+    },
+    {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${supplierAPIKey}`
+    }
+  );
+};
+
+const supplierAPI = {
+  getGCloudFilters
+};
+
+export { supplierAPI };

--- a/src/main/services/helpers/api.ts
+++ b/src/main/services/helpers/api.ts
@@ -1,0 +1,126 @@
+import { BaseFetchResult, FetchRequestInit, FetchResult, FetchResultStatus, HTTPMethod } from '../types/helpers/api';
+import { FormatURLParams } from '../types/helpers/url';
+import { FetchError, FetchTimeoutError } from './errors';
+import { formatURL } from './url';
+
+/**
+ * If the result status is 'error' it will throw an exception,
+ * otherwise it returns the data
+ * @param result
+ * @returns
+ */
+const unwrap = <T>(result: BaseFetchResult<T>): T => {
+  if (result.status === FetchResultStatus.ERROR) {
+    throw result.error;
+  }
+
+  return result.data;
+};
+
+/**
+ * Calls the NODE Fetch API and timeout if the request takes too long,
+ * otherwise it returns the response
+ * @param fetchOptions 
+ * @param urlParams 
+ * @param timeout 
+ * @returns 
+ */
+const fetchWithOptionalTimeout = async (fetchOptions: FetchRequestInit, urlParams: FormatURLParams, timeout?: number): Promise<Response> => {
+  const url: string = formatURL(urlParams);
+  let id: NodeJS.Timeout;
+
+  if (timeout !== undefined) {
+    const controller = new AbortController();
+    id = setTimeout(() => controller.abort(new FetchTimeoutError(fetchOptions.method, urlParams.baseURL + urlParams.path, timeout)), timeout);
+
+    fetchOptions.signal = controller.signal;
+  }
+
+  const response = await fetch(url, fetchOptions);
+
+  if (id !== undefined) {
+    clearTimeout(id);
+  }
+
+  return response;
+};
+
+/**
+ * Makes a call with the NODE Fetch API and
+ * retuns an FetchResultOK if there are no errors,
+ * otherwise it returns a FetchResultError 
+ * @param fetchOptions 
+ * @param urlParams 
+ * @param timeout 
+ * @returns 
+ */
+const genericFetch = async <T>(fetchOptions: FetchRequestInit, urlParams: FormatURLParams, timeout?: number): Promise<FetchResult<T>> => {
+  let result: BaseFetchResult<T>;
+
+  try {
+    const response = await fetchWithOptionalTimeout(fetchOptions, urlParams, timeout);
+
+    if (response.status !== 200) {
+      throw new FetchError(
+        fetchOptions.method,
+        urlParams.baseURL + urlParams.path,
+        response.status
+      );
+    }
+
+    result = {
+      status: FetchResultStatus.OK,
+      data: await response.json(),
+    };
+  } catch (error) {
+    result = {
+      status: FetchResultStatus.ERROR,
+      error: error,
+    };
+  }
+
+  return {
+    ...result,
+    unwrap: () => unwrap<T>(result)
+  };
+};
+
+/**
+ * Makes a GET request with the NODE Fetch API
+ * @param urlParams 
+ * @param headers 
+ * @param timeout 
+ * @returns 
+ */
+const genericFecthGet = async <T>(urlParams: FormatURLParams, headers: { [key: string]: string }, timeout?: number): Promise<FetchResult<T>> => {
+  return genericFetch<T>(
+    {
+      method: HTTPMethod.GET,
+      headers: headers
+    },
+    urlParams,
+    timeout
+  );
+};
+
+/**
+ * Makes a POST request with the NODE Fetch API
+ * @param urlParams 
+ * @param headers 
+ * @param data 
+ * @param timeout 
+ * @returns 
+ */
+const genericFecthPost = async <T>(urlParams: FormatURLParams, headers: { [key: string]: string }, data?: { [key: string]: string }, timeout?: number): Promise<FetchResult<T>> => {
+  return genericFetch<T>(
+    {
+      method: HTTPMethod.POST,
+      headers: headers,
+      body: JSON.stringify(data ?? {})
+    },
+    urlParams,
+    timeout
+  );
+};
+
+export { genericFecthGet, genericFecthPost };

--- a/src/main/services/helpers/errors.ts
+++ b/src/main/services/helpers/errors.ts
@@ -1,0 +1,17 @@
+import { HTTPMethod } from '../types/helpers/api';
+
+class FetchError extends Error {
+  constructor(method: HTTPMethod, url: string, status: number) {
+    super(`The call ${method} ${url} returned an unexpected status: ${status}`);
+  }
+}
+
+class FetchTimeoutError extends Error {
+  constructor(method: HTTPMethod, url: string, timoutMs: number) {
+    const timeoutSeconds = (timoutMs / 1000).toFixed(2);
+
+    super(`The call ${method} ${url} did not respond within ${timeoutSeconds}`);
+  }
+}
+
+export { FetchError, FetchTimeoutError };

--- a/src/main/services/helpers/url.ts
+++ b/src/main/services/helpers/url.ts
@@ -1,0 +1,25 @@
+import { FormatURLParams } from '../types/helpers/url';
+
+/**
+ * Formats a URL from the given options
+ * @param options 
+ * @returns 
+ */
+const formatURL = (options: FormatURLParams): string => {
+  const { baseURL, params, queryParams } = options;
+  let { path } = options;
+
+  if (options.params) {
+    params.forEach(([param, value]) => path = path.replace(param, value));
+  }
+
+  const url = new URL(path, baseURL);
+
+  if (queryParams !== undefined) {
+    url.search = (new URLSearchParams(queryParams)).toString();
+  }
+
+  return url.toString();
+};
+
+export { formatURL };

--- a/src/main/services/publicProcurementGateway.ts
+++ b/src/main/services/publicProcurementGateway.ts
@@ -1,0 +1,15 @@
+import { organisationAPI } from './publicProcurementGateway/organisation/api';
+import { oAuthAPI } from './publicProcurementGateway/oAuth/api';
+import { oAuthURL } from './publicProcurementGateway/oAuth/url';
+
+const ppg = {
+  api: {
+    oAuth: oAuthAPI,
+    organisation: organisationAPI
+  },
+  url: {
+    oAuth: oAuthURL
+  }
+};
+
+export { ppg };

--- a/src/main/services/publicProcurementGateway/oAuth/api.ts
+++ b/src/main/services/publicProcurementGateway/oAuth/api.ts
@@ -1,0 +1,54 @@
+import config from 'config';
+import { AuthCredentials, EndPoints, RefreshData } from '../../types/publicProcurementGateway/oAuth/api';
+import { genericFecthPost } from 'main/services/helpers/api';
+import { FetchResult } from 'main/services/types/helpers/api';
+
+const baseURL: string = process.env.AUTH_SERVER_BASE_URL;
+const clientId: string = process.env.AUTH_SERVER_CLIENT_ID;
+const clientSecret: string = process.env.AUTH_SERVER_CLIENT_SECRET;
+
+const endPoints: EndPoints = {
+  token: config.get('authenticationService.token-endpoint'),
+  validateToken: config.get('authenticationService.token_validation_endpoint'),
+};
+
+const postRefreshToken = async (authCredentials: AuthCredentials): Promise<FetchResult<RefreshData>> => {
+  return genericFecthPost<RefreshData>(
+    {
+      baseURL: baseURL,
+      path: endPoints.token
+    },
+    {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    {
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: config.get('authenticationService.refresh_token'),
+      ...authCredentials
+    }
+  );
+};
+
+const postValidateToken = async (accessToken: string): Promise<FetchResult<boolean>> => {
+  return genericFecthPost<boolean>(
+    {
+      baseURL: baseURL,
+      path: endPoints.validateToken,
+      queryParams: {
+        'client-id': clientId
+      }
+    },
+    {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`
+    }
+  );
+};
+
+const oAuthAPI = {
+  postRefreshToken,
+  postValidateToken
+};
+
+export { oAuthAPI };

--- a/src/main/services/publicProcurementGateway/oAuth/url.ts
+++ b/src/main/services/publicProcurementGateway/oAuth/url.ts
@@ -1,0 +1,56 @@
+import config from 'config';
+import { EndPoints, LogInParams } from '../../types/publicProcurementGateway/oAuth/url';
+import { Request } from 'express';
+import { formatURL } from 'main/services/helpers/url';
+
+const baseURL: string = process.env.AUTH_SERVER_BASE_URL;
+const casURL: string = process.env.CAT_URL;
+const clientId: string = process.env.AUTH_SERVER_CLIENT_ID;
+
+const endPoints: EndPoints = {
+  login: '/security/authorize',
+  callback: '/receiver',
+  logout: config.get('authenticationService.logout'),
+  logoutCallback: config.get('authenticationService.logout_callback')
+};
+
+const loginURL = (req?: Request): string => {
+  const logInParams: LogInParams = {
+    response_type: 'code',
+    scope: 'openid profile FirstName LastName  email  offline_access',
+    client_id: clientId,
+    redirect_uri: casURL + endPoints.callback
+  };
+
+  if (req !== undefined && req.session.supplier_qa_url) {
+    logInParams.urlId = req.session.supplier_qa_url;
+  }
+
+  return formatURL(
+    {
+      baseURL: baseURL,
+      path: endPoints.login,
+      queryParams: logInParams
+    }
+  );
+};
+
+const logoutURL = (): string => {
+  return formatURL(
+    {
+      baseURL: baseURL,
+      path: endPoints.logout,
+      queryParams: {
+        'client-id': clientId,
+        'redirect-uri': `${casURL}${endPoints.logoutCallback}`
+      }
+    }
+  );
+};
+
+const oAuthURL = {
+  login: loginURL,
+  logout: logoutURL
+};
+
+export { oAuthURL };

--- a/src/main/services/publicProcurementGateway/organisation/api.ts
+++ b/src/main/services/publicProcurementGateway/organisation/api.ts
@@ -1,0 +1,69 @@
+import { genericFecthGet } from 'main/services/helpers/api';
+import { EndPoints, Organisation, OrganisationUsers, UserProfile } from '../../types/publicProcurementGateway/organisation/api';
+import { FetchResult } from 'main/services/types/helpers/api';
+
+const baseURL: string = process.env.CONCLAVE_WRAPPER_API_BASE_URL;
+
+const headers = {
+  'Content-Type': 'application/json',
+  'x-api-key': process.env.CONCLAVE_WRAPPER_API_KEY
+};
+
+const endPoints: EndPoints = {
+  organisation: '/organisation-profiles/:organisation-id',
+  organisationUsers: '/organisation-profiles/:organisation-id/users',
+  userProfiles: '/user-profiles'
+};
+
+// GET /organisation-profiles/:organisation-id
+const getOrganisation = async (organisationId: string, queryParams?: { [key: string]: string }): Promise<FetchResult<Organisation>> => {
+  return genericFecthGet<Organisation>(
+    {
+      baseURL: baseURL,
+      path: endPoints.organisation,
+      params: [
+        [':organisation-id', organisationId]
+      ],
+      queryParams: queryParams
+    },
+    headers
+  );
+};
+
+// GET /organisation-profiles/:organisation-id/users
+const getOrganisationUsers = async (organisationId: string, queryParams?: { [key: string]: string }): Promise<FetchResult<OrganisationUsers>> => {
+  return genericFecthGet<OrganisationUsers>(
+    {
+      baseURL: baseURL,
+      path: endPoints.organisationUsers,
+      params: [
+        [':organisation-id', organisationId]
+      ],
+      queryParams: queryParams
+    },
+    headers
+  );
+};
+
+// GET /user-profiles
+const getUserProfiles = async (userId: string, queryParams?: { [key: string]: string }): Promise<FetchResult<UserProfile>> => {
+  return genericFecthGet<UserProfile>(
+    {
+      baseURL: baseURL,
+      path: endPoints.userProfiles,
+      queryParams: {
+        'user-Id': userId,
+        ...queryParams
+      }
+    },
+    headers
+  );
+};
+
+const organisationAPI = {
+  getOrganisation,
+  getOrganisationUsers,
+  getUserProfiles
+};
+
+export { organisationAPI };

--- a/src/main/services/types/agreementsService/api.ts
+++ b/src/main/services/types/agreementsService/api.ts
@@ -1,0 +1,13 @@
+type EndPoints = {
+  agreement: string
+  agreementLots: string
+  agreementLot: string
+  agreementLotSuppliers: string,
+  agreementLotEventTypes: string
+}
+
+type AgreementLotEventType = {
+  type: string
+}
+
+export { EndPoints, AgreementLotEventType };

--- a/src/main/services/types/bankHolidays/api.ts
+++ b/src/main/services/types/bankHolidays/api.ts
@@ -1,0 +1,23 @@
+type EndPoints = {
+  bankHolidays: string
+};
+
+type BankHolidayEvent = {
+  title: string
+  date: string
+  notes: string
+  bunting: boolean
+}
+
+type BankHolidayDivision = {
+  division: string
+  events: BankHolidayEvent[]
+}
+
+type BankHolidays = {
+  'england-and-wales': BankHolidayDivision
+  'scotland': BankHolidayDivision
+  'northern-ireland': BankHolidayDivision
+}
+
+export { EndPoints, BankHolidays };

--- a/src/main/services/types/contentService/api.ts
+++ b/src/main/services/types/contentService/api.ts
@@ -1,0 +1,38 @@
+type EndPoints = {
+  menu: string
+};
+
+type ContentServiceMenuItem = {
+  id: number
+  order: number
+  parent: number
+  title: string
+  url: string
+  attr: string
+  target: string
+  classes: string
+  xfn: string
+  description: string
+  object_id: number
+  object: string
+  object_slug: string
+  type: string
+  type_label: string
+}
+
+type ContentServiceMenu = {
+  ID: number
+  name: string
+  slug: string
+  description: string
+  count: number
+  items: ContentServiceMenuItem[]
+  meta: {
+    links: {
+      collection: string
+      self: string
+    }
+  }
+}
+
+export { EndPoints, ContentServiceMenu };

--- a/src/main/services/types/gCloud/search/api.ts
+++ b/src/main/services/types/gCloud/search/api.ts
@@ -1,0 +1,60 @@
+type EndPoints = {
+  servicesSearch: string
+  servicesAggregations: string
+}
+
+type GCloudService = {
+  links: {
+    next: string
+  }
+  meta: {
+    query: { [key: string]: string }
+    results_per_page: number
+    took: number
+    total: number
+  }
+}
+
+type GCloudServiceSearchDocument = {
+  frameworkName: string
+  highlight: {
+    frameworkName: [string]
+    id: [string]
+    lot: [string]
+    lotName: [string]
+    serviceBenefits: [string]
+    serviceCategories: [string]
+    serviceDescription: [string]
+    serviceFeatures: [string]
+    serviceName: [string]
+    supplierName: [string]
+  }
+  id: string
+  lot: string
+  lotName: string
+  serviceBenefits: string[]
+  serviceCategories: string[]
+  serviceDescription: string
+  serviceFeatures: string[]
+  serviceName: string
+  supplierName: string
+}
+
+type GCloudServiceSearch = GCloudService & {
+  documents: GCloudServiceSearchDocument[]
+}
+
+type GCloudServiceAggregation = {
+  lot: {
+    [key: string]: number
+  }
+  serviceCategories?: {
+    [key: string]: number
+  }
+}
+
+type GCloudServiceAggregations = GCloudService & {
+  aggregations: GCloudServiceAggregation
+}
+
+export { EndPoints, GCloudServiceSearch, GCloudServiceAggregations };

--- a/src/main/services/types/gCloud/service/api.ts
+++ b/src/main/services/types/gCloud/service/api.ts
@@ -1,0 +1,92 @@
+type EndPoints = {
+  service: string
+  supplier: string
+  supplierFramework: string
+}
+
+type GCloudService = {
+  serviceMadeUnavailableAuditEvent: string | null
+  services: {
+    [key: string]: boolean | number | string | string[] | object
+  }
+}
+
+type GCloudSupplier = {
+  suppliers: {
+    companiesHouseNumber: string
+    companyDetailsConfirmed: boolean
+    contactInformation: [
+      {
+        address1: string
+        city: string
+        contactName: string
+        email: string
+        id: number
+        links: {
+          self: string
+        }
+        personalDataRemoved: boolean
+        phoneNumber: string
+        postcode: string
+      }
+    ]
+    description: string
+    dunsNumber: string
+    id: number
+    links: {
+      self: string
+    }
+    name: string
+    organisationSize: string
+    registeredName: string
+    registrationCountry: string
+    service_counts: {
+      [key: string]: number
+    }
+    tradingStatus: string
+    vatNumber: string
+  }
+}
+
+type GCloudSupplierFramework = {
+  frameworkInterest: {
+    agreedVariations: object
+    agreementDetails: {
+      frameworkAgreementVersion: string
+      signerName: string
+      signerRole: string
+      uploaderUserEmail: string
+      uploaderUserId: number
+      uploaderUserName: string
+    }
+    agreementId: number
+    agreementPath: string | null,
+    agreementReturned: boolean
+    agreementReturnedAt: string
+    agreementStatus: string
+    allowDeclarationReuse: boolean
+    applicationCompanyDetailsConfirmed: boolean
+    countersigned: boolean
+    countersignedAt: string
+    countersignedDetails: {
+      approvedByUserEmail: string
+      approvedByUserId: number
+      approvedByUserName: string
+      countersignerName: string
+      countersignerRole: string
+    }
+    countersignedPath: string
+    declaration: {
+      [key: string]: string | boolean
+    }
+    frameworkFamily: string
+    frameworkFramework: string
+    frameworkSlug: string
+    onFramework: boolean
+    prefillDeclarationFromFrameworkSlug: string
+    supplierId: number
+    supplierName: string
+  }
+}
+
+export { EndPoints, GCloudService, GCloudSupplier, GCloudSupplierFramework };

--- a/src/main/services/types/gCloud/supplier/api.ts
+++ b/src/main/services/types/gCloud/supplier/api.ts
@@ -1,0 +1,28 @@
+type EndPoints = {
+  filters: string
+}
+
+type GCloudFilterQueryParams = {
+  lot: string
+  serviceCategories: string
+  parentCategory: string
+}
+
+type GCloudFilter = {
+  id: string
+  label: string
+  name: string
+  value: string
+}
+
+type GCloudFilters = {
+  [key: string]: {
+    [key: string]: {
+      filters: GCloudFilter[]
+      label: string
+      slug: string
+    }
+  } 
+}
+
+export { EndPoints, GCloudFilterQueryParams, GCloudFilters };

--- a/src/main/services/types/helpers/api.ts
+++ b/src/main/services/types/helpers/api.ts
@@ -1,0 +1,31 @@
+enum HTTPMethod {
+  GET = 'GET',
+  POST = 'POST'
+}
+
+interface FetchRequestInit extends Omit<RequestInit, 'method'> {
+  method: HTTPMethod
+}
+
+enum FetchResultStatus {
+  OK = 0,
+  ERROR = 1
+}
+
+type FetchResultOK<T> = {
+  status: FetchResultStatus.OK
+  data: T
+}
+
+type FetchResultError = {
+  status: FetchResultStatus.ERROR
+  error: any
+}
+
+type BaseFetchResult<T> = FetchResultOK<T> | FetchResultError
+
+type FetchResult<T> = BaseFetchResult<T> & {
+  unwrap: () => T
+}
+
+export { HTTPMethod, FetchRequestInit, BaseFetchResult, FetchResult, FetchResultStatus, FetchResultOK, FetchResultError };

--- a/src/main/services/types/helpers/url.ts
+++ b/src/main/services/types/helpers/url.ts
@@ -1,0 +1,9 @@
+
+type FormatURLParams = {
+  baseURL: string
+  path: string
+  params?: Array<[string, string]>
+  queryParams?: { [key: string]: string }
+}
+
+export { FormatURLParams };

--- a/src/main/services/types/publicProcurementGateway/oAuth/api.ts
+++ b/src/main/services/types/publicProcurementGateway/oAuth/api.ts
@@ -1,0 +1,19 @@
+type AuthCredentials = {
+  refresh_token?: string
+  code?: string
+  redirect_uri?: string
+  response_type?: string
+}
+
+type RefreshData = {
+  access_token: string
+  session_state: string
+  refresh_token: string
+}
+
+type EndPoints = {
+  token: string
+  validateToken: string
+};
+
+export { AuthCredentials, RefreshData, EndPoints };

--- a/src/main/services/types/publicProcurementGateway/oAuth/url.ts
+++ b/src/main/services/types/publicProcurementGateway/oAuth/url.ts
@@ -1,0 +1,16 @@
+type EndPoints = {
+  login: string
+  callback: string
+  logout: string
+  logoutCallback: string
+};
+
+type LogInParams = {
+  response_type: string
+  scope: string
+  client_id: string
+  redirect_uri: string
+  urlId?: string
+}
+
+export { EndPoints, LogInParams };

--- a/src/main/services/types/publicProcurementGateway/organisation/api.ts
+++ b/src/main/services/types/publicProcurementGateway/organisation/api.ts
@@ -1,0 +1,25 @@
+type Organisation = {
+  identifier: {
+    legalName: string
+  }
+}
+
+type OrganisationUsers = {
+  pageCount: number
+  userList: UserProfile[]
+}
+
+type UserProfile = {
+  userName: string
+  firstName: string
+  lastName: string
+  telephone: string
+}
+
+type EndPoints = {
+  organisation: string
+  organisationUsers: string
+  userProfiles: string
+};
+
+export { Organisation, OrganisationUsers, UserProfile, EndPoints };

--- a/src/test/unit/services/agreementsService/api.test.ts
+++ b/src/test/unit/services/agreementsService/api.test.ts
@@ -1,0 +1,198 @@
+import { AgreementDetail } from '@common/middlewares/models/agreement-detail';
+import { LotDetail } from '@common/middlewares/models/lot-detail';
+import { LotSupplier } from '@common/middlewares/models/lot-supplier';
+import { expect } from 'chai';
+import { agreementsServiceAPI } from 'main/services/agreementsService/api';
+import { AgreementLotEventType } from 'main/services/types/agreementsService/api';
+import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+
+describe('Agrements Service API helpers', () => {
+  const baseURL = process.env.AGREEMENTS_SERVICE_API_URL;
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  const agreementId = 'agreementId-1234';
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('getAgreement', () => {
+    it('calls the get agreement endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `/agreements/${agreementId}`,
+        headers: headers
+      }).reply(200, { name: 'myName', endDate: 'myEndDate' });
+
+      const findAgreementResult = await agreementsServiceAPI.getAgreement(agreementId) as FetchResultOK<AgreementDetail>;
+
+      expect(findAgreementResult.status).to.eq(FetchResultStatus.OK);
+      expect(findAgreementResult.data).to.eql({ name: 'myName', endDate: 'myEndDate' });
+    });
+  });
+
+  describe('getAgreementLots', () => {
+    it('calls the get agreement lots endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `/agreements/${agreementId}/lots`,
+        headers: headers
+      }).reply(200, [
+        {
+          number: 'myNumber',
+          name: 'myName',
+          startDate: 'myStartDate',
+          endDate: 'myEndDate',
+          description: 'myDescription',
+          suppliers: 'mySuppliers',
+          type: 'myType',
+          routesToMarket: 'myRoutesToMarket',
+          sectors: ['sectors'],
+          relatedAgreementLots: [{}],
+          rules: [{}]
+        }
+      ]);
+
+      const getAgreementLotsResult = await agreementsServiceAPI.getAgreementLots(agreementId) as FetchResultOK<LotDetail[]>;
+
+      expect(getAgreementLotsResult.status).to.eq(FetchResultStatus.OK);
+      expect(getAgreementLotsResult.data).to.eql([
+        {
+          number: 'myNumber',
+          name: 'myName',
+          startDate: 'myStartDate',
+          endDate: 'myEndDate',
+          description: 'myDescription',
+          suppliers: 'mySuppliers',
+          type: 'myType',
+          routesToMarket: 'myRoutesToMarket',
+          sectors: ['sectors'],
+          relatedAgreementLots: [{}],
+          rules: [{}]
+        }
+      ]);
+    });
+  });
+
+  describe('getAgreementLot', () => {
+    it('calls the get agreement lot endpoint with the correct url and headers', async () => {
+      const lotId = 'lotId-1234';
+
+      mockPool.intercept({
+        method: 'GET',
+        path: `/agreements/${agreementId}/lots/${lotId}`,
+        headers: headers
+      }).reply(200, {
+        number: 'myNumber',
+        name: 'myName',
+        startDate: 'myStartDate',
+        endDate: 'myEndDate',
+        description: 'myDescription',
+        suppliers: 'mySuppliers',
+        type: 'myType',
+        routesToMarket: 'myRoutesToMarket',
+        sectors: ['sectors'],
+        relatedAgreementLots: [{}],
+        rules: [{}]
+      });
+
+      const findAgreementLotResult = await agreementsServiceAPI.getAgreementLot(agreementId, lotId) as FetchResultOK<LotDetail>;
+
+      expect(findAgreementLotResult.status).to.eq(FetchResultStatus.OK);
+      expect(findAgreementLotResult.data).to.eql({
+        number: 'myNumber',
+        name: 'myName',
+        startDate: 'myStartDate',
+        endDate: 'myEndDate',
+        description: 'myDescription',
+        suppliers: 'mySuppliers',
+        type: 'myType',
+        routesToMarket: 'myRoutesToMarket',
+        sectors: ['sectors'],
+        relatedAgreementLots: [{}],
+        rules: [{}]
+      });
+    });
+  });
+
+  describe('getAgreementLotSuppliers', () => {
+    it('calls the get agreement lot suppliers endpoint with the correct url and headers', async () => {
+      const lotId = 'lotId-1234';
+
+      mockPool.intercept({
+        method: 'GET',
+        path: `/agreements/${agreementId}/lots/${lotId}/suppliers`,
+        headers: headers
+      }).reply(200, [
+        {
+          supplierName: 'mySupplierName',
+          supplierAddress: {
+            streetAddress: 'myStreetAddress',
+            locality: 'myLocality',
+            region: 'myRegion',
+            postalCode: 'myPostalCode',
+            countryName: 'myCountryName',
+            countryCode: 'myCountryCode'
+          },
+          supplierContactName: 'mySupplierContactName',
+          supplierContactEmail: 'mySupplierContactEmail',
+          supplierWebsite: 'mySupplierWebsite',
+          supplierId: 'mySupplierId',
+          supplierOrganisation: 'mySupplierOrganisation',
+          responseState: 'myResponseState',
+          responseDate: 'myResponseDate',
+          score: 'myScore',
+          rank: 'myRank'
+        }
+      ]);
+
+      const getAgreementLotSuppliersResult = await agreementsServiceAPI.getAgreementLotSuppliers(agreementId, lotId) as FetchResultOK<LotSupplier[]>;
+
+      expect(getAgreementLotSuppliersResult.status).to.eq(FetchResultStatus.OK);
+      expect(getAgreementLotSuppliersResult.data).to.eql([
+        {
+          supplierName: 'mySupplierName',
+          supplierAddress: {
+            streetAddress: 'myStreetAddress',
+            locality: 'myLocality',
+            region: 'myRegion',
+            postalCode: 'myPostalCode',
+            countryName: 'myCountryName',
+            countryCode: 'myCountryCode'
+          },
+          supplierContactName: 'mySupplierContactName',
+          supplierContactEmail: 'mySupplierContactEmail',
+          supplierWebsite: 'mySupplierWebsite',
+          supplierId: 'mySupplierId',
+          supplierOrganisation: 'mySupplierOrganisation',
+          responseState: 'myResponseState',
+          responseDate: 'myResponseDate',
+          score: 'myScore',
+          rank: 'myRank'
+        }
+      ]);
+    });
+  });
+
+  describe('getAgreementLotEventTypes', () => {
+    it('calls the get agreement lot event types endpoint with the correct url and headers', async () => {
+      const lotId = 'lotId-1234';
+
+      mockPool.intercept({
+        method: 'GET',
+        path: `/agreements/${agreementId}/lots/${lotId}/event-types`,
+        headers: headers
+      }).reply(200, [{ type: 'myType' }]);
+
+      const getAgreementLotEventTypesResult = await agreementsServiceAPI.getAgreementLotEventTypes(agreementId, lotId) as FetchResultOK<AgreementLotEventType[]>;
+
+      expect(getAgreementLotEventTypesResult.status).to.eq(FetchResultStatus.OK);
+      expect(getAgreementLotEventTypesResult.data).to.eql([{ type: 'myType' }]);
+    });
+  });
+});

--- a/src/test/unit/services/bankHolidays/api.test.ts
+++ b/src/test/unit/services/bankHolidays/api.test.ts
@@ -1,0 +1,85 @@
+import config from 'config';
+import { expect } from 'chai';
+import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { bankHolidaysAPI } from 'main/services/bankHolidays/api';
+import { BankHolidays } from 'main/services/types/bankHolidays/api';
+
+describe('Bank Holidays API helpers', () => {
+  const baseURL = config.get('bankholidayservice.BASEURL') as string;
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('getBankHolidays', () => {
+    it('calls the get bank holidays endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: '/bank-holidays.json',
+        headers: headers
+      }).reply(200, {
+        'england-and-wales': [
+          {
+            title: 'Christmas Day',
+            date: '2018-12-25',
+            notes: '',
+            bunting: true
+          }
+        ],
+        'scotland': [
+          {
+            title: 'Christmas Day',
+            date: '2018-12-25',
+            notes: '',
+            bunting: true
+          }
+        ],
+        'northern-ireland': [
+          {
+            title: 'Christmas Day',
+            date: '2018-12-25',
+            notes: '',
+            bunting: true
+          }
+        ]
+      });
+
+      const getBankHolidaysResult = await bankHolidaysAPI.getBankHolidays() as FetchResultOK<BankHolidays>;
+
+      expect(getBankHolidaysResult.status).to.eq(FetchResultStatus.OK);
+      expect(getBankHolidaysResult.data).to.eql({
+        'england-and-wales': [
+          {
+            title: 'Christmas Day',
+            date: '2018-12-25',
+            notes: '',
+            bunting: true
+          }
+        ],
+        'scotland': [
+          {
+            title: 'Christmas Day',
+            date: '2018-12-25',
+            notes: '',
+            bunting: true
+          }
+        ],
+        'northern-ireland': [
+          {
+            title: 'Christmas Day',
+            date: '2018-12-25',
+            notes: '',
+            bunting: true
+          }
+        ]
+      });
+    });
+  });
+});

--- a/src/test/unit/services/contentService/api.test.ts
+++ b/src/test/unit/services/contentService/api.test.ts
@@ -1,0 +1,91 @@
+import config from 'config';
+import { expect } from 'chai';
+import { FetchResultError, FetchResultOK, FetchResultStatus, HTTPMethod } from 'main/services/types/helpers/api';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { contentServiceAPI } from 'main/services/contentService/api';
+import { FetchTimeoutError } from 'main/services/helpers/errors';
+import { ContentServiceMenu } from 'main/services/types/contentService/api';
+
+describe('Content service API helpers', () => {
+  const baseURL = config.get('contentService.BASEURL') as string;
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('getMenu', () => {
+    const menuId = 'menuId-1234';
+    const path = `/wp-json/wp-api-menus/v2/menus/${menuId}`;
+
+    it('calls the get menu endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, {
+        ID: 1234,
+        name: 'myName',
+        slug: 'mySlug',
+        description: 'myDescription',
+        count: 234,
+        items: [],
+        meta: {
+          links: {
+            collection: 'myCollection',
+            self: 'mySelf'
+          }
+        }
+      });
+
+      const findMenuResult = await contentServiceAPI.getMenu(menuId) as FetchResultOK<ContentServiceMenu>;
+
+      expect(findMenuResult.status).to.eq(FetchResultStatus.OK);
+      expect(findMenuResult.data).to.eql({
+        ID: 1234,
+        name: 'myName',
+        slug: 'mySlug',
+        description: 'myDescription',
+        count: 234,
+        items: [],
+        meta: {
+          links: {
+            collection: 'myCollection',
+            self: 'mySelf'
+          }
+        }
+      });
+    });
+
+    it('returns an error if the delay is too long', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, {
+        ID: 1234,
+        name: 'myName',
+        slug: 'mySlug',
+        description: 'myDescription',
+        count: 234,
+        items: [],
+        meta: {
+          links: {
+            collection: 'myCollection',
+            self: 'mySelf'
+          }
+        }
+      }).delay(160);
+
+      const findMenuResult = await contentServiceAPI.getMenu(menuId) as FetchResultError;
+
+      expect(findMenuResult.status).to.eq(FetchResultStatus.ERROR);
+      expect(findMenuResult.error).to.eql(new FetchTimeoutError(HTTPMethod.GET, baseURL + '/wp-json/wp-api-menus/v2/menus/:menu-id', 15));
+    });
+  });
+});

--- a/src/test/unit/services/gCloud/search/api.test.ts
+++ b/src/test/unit/services/gCloud/search/api.test.ts
@@ -1,0 +1,184 @@
+import { expect } from 'chai';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
+import { searchAPI } from 'main/services/gCloud/search/api';
+import { GCloudServiceAggregations, GCloudServiceSearch } from 'main/services/types/gCloud/search/api';
+
+describe('G-Cloud Search API helpers', () => {
+  const baseURL = process.env.GCLOUD_SEARCH_API_URL;
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.GCLOUD_SEARCH_API_TOKEN}`
+  };
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('getServicesSearch', () => {
+    const path = '/g-cloud-42/services/search';
+
+    it('calls the get g-cloud services search endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, {
+        documents: [{}],
+        links: {
+          next: 'nextLink'
+        },
+        meta: {
+          query: {},
+          results_per_page: 123,
+          took: 234,
+          total: 345
+        }
+      });
+
+      const servicesSearchResult = await searchAPI.getServicesSearch() as FetchResultOK<GCloudServiceSearch>;
+
+      expect(servicesSearchResult.status).to.eq(FetchResultStatus.OK);
+      expect(servicesSearchResult.data).to.eql({
+        documents: [{}],
+        links: {
+          next: 'nextLink'
+        },
+        meta: {
+          query: {},
+          results_per_page: 123,
+          took: 234,
+          total: 345
+        }
+      });
+    });
+
+    it('calls the get g-cloud services search endpoint with the correct url, headers and query params', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `${path}?my_param=myParam`,
+        headers: headers
+      }).reply(200, {
+        documents: [{}],
+        links: {
+          next: 'nextLink'
+        },
+        meta: {
+          query: {},
+          results_per_page: 123,
+          took: 234,
+          total: 345
+        }
+      });
+
+      const servicesSearchResult = await searchAPI.getServicesSearch({ my_param: 'myParam' }) as FetchResultOK<GCloudServiceSearch>;
+
+      expect(servicesSearchResult.status).to.eq(FetchResultStatus.OK);
+      expect(servicesSearchResult.data).to.eql({
+        documents: [{}],
+        links: {
+          next: 'nextLink'
+        },
+        meta: {
+          query: {},
+          results_per_page: 123,
+          took: 234,
+          total: 345
+        }
+      });
+    });
+  });
+
+  describe('gCloudServicesAggregations', () => {
+    const path = '/g-cloud-42/services/aggregations';
+
+    it('calls the get g-cloud services aggregations endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, {
+        aggregations: {
+          lot: {
+            'myLot': 456
+          }
+        },
+        links: {
+          next: 'nextLink'
+        },
+        meta: {
+          query: {},
+          results_per_page: 123,
+          took: 234,
+          total: 345
+        }
+      });
+
+      const servicesAggregationsResult = await searchAPI.getServicesAggregations() as FetchResultOK<GCloudServiceAggregations>;
+
+      expect(servicesAggregationsResult.status).to.eq(FetchResultStatus.OK);
+      expect(servicesAggregationsResult.data).to.eql({
+        aggregations: {
+          lot: {
+            'myLot': 456
+          }
+        },
+        links: {
+          next: 'nextLink'
+        },
+        meta: {
+          query: {},
+          results_per_page: 123,
+          took: 234,
+          total: 345
+        }
+      });
+    });
+
+    it('calls the get g-cloud services aggregations endpoint with the correct url, headers and query params', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `${path}?my_param=myParam`,
+        headers: headers
+      }).reply(200, {
+        aggregations: {
+          lot: {
+            'myLot': 456
+          }
+        },
+        links: {
+          next: 'nextLink'
+        },
+        meta: {
+          query: {},
+          results_per_page: 123,
+          took: 234,
+          total: 345
+        }
+      });
+
+      const servicesAggregationsResult = await searchAPI.getServicesAggregations({ my_param: 'myParam' }) as FetchResultOK<GCloudServiceAggregations>;
+
+      expect(servicesAggregationsResult.status).to.eq(FetchResultStatus.OK);
+      expect(servicesAggregationsResult.data).to.eql({
+        aggregations: {
+          lot: {
+            'myLot': 456
+          }
+        },
+        links: {
+          next: 'nextLink'
+        },
+        meta: {
+          query: {},
+          results_per_page: 123,
+          took: 234,
+          total: 345
+        }
+      });
+    });
+  });
+});

--- a/src/test/unit/services/gCloud/servcies/api.test.ts
+++ b/src/test/unit/services/gCloud/servcies/api.test.ts
@@ -1,0 +1,232 @@
+import { expect } from 'chai';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
+import { serviceAPI } from 'main/services/gCloud/service/api';
+import { GCloudService, GCloudSupplier, GCloudSupplierFramework } from 'main/services/types/gCloud/service/api';
+
+describe('G-Cloud Service API helpers', () => {
+  const baseURL = process.env.GCLOUD_SERVICES_API_URL;
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.GCLOUD_TOKEN}`
+  };
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('getService', () => {
+    const serviceId = 'serviceId-1234';
+    const path = `/services/${serviceId}`;
+
+    it('calls the get g-cloud services endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, {
+        serviceMadeUnavailableAuditEvent: null,
+        services: {
+          myService: true
+        }
+      });
+
+      const findServiceResult = await serviceAPI.getService(serviceId) as FetchResultOK<GCloudService>;
+
+      expect(findServiceResult.status).to.eq(FetchResultStatus.OK);
+      expect(findServiceResult.data).to.eql({
+        serviceMadeUnavailableAuditEvent: null,
+        services: {
+          myService: true
+        }
+      });
+    });
+  });
+
+  describe('getSupplier', () => {
+    const supplierId = 'supplierId-1234';
+    const path = `/suppliers/${supplierId}`;
+
+    it('calls the get g-cloud suppliers endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, {
+        suppliers: {
+          companiesHouseNumber: 'myCompaniesHouseNumber',
+          companyDetailsConfirmed: true,
+          contactInformation: [
+            {
+              address1: 'myAddress1',
+              city: 'myCity',
+              contactName: 'myContactName',
+              email: 'myEmail',
+              id: 123,
+              links: {
+                self: 'mySelf'
+              },
+              personalDataRemoved: false,
+              phoneNumber: 'myPhoneNumber',
+              postcode: 'myPostcode'
+            }
+          ],
+          description: 'myDescription',
+          dunsNumber: 'myDunsNumber',
+          id: 234,
+          links: {
+            self: 'mySelf'
+          },
+          name: 'myName',
+          organisationSize: 'myOrganisationSize',
+          registeredName: 'myRegisteredName',
+          registrationCountry: 'myRegistrationCountry',
+          service_counts: {
+            'serviceCount': 345
+          },
+          tradingStatus: 'myTradingStatus',
+          vatNumber: 'vatNumber'
+        }
+      });
+
+      const findSupplierResult = await serviceAPI.getSupplier(supplierId) as FetchResultOK<GCloudSupplier>;
+
+      expect(findSupplierResult.status).to.eq(FetchResultStatus.OK);
+      expect(findSupplierResult.data).to.eql({
+        suppliers: {
+          companiesHouseNumber: 'myCompaniesHouseNumber',
+          companyDetailsConfirmed: true,
+          contactInformation: [
+            {
+              address1: 'myAddress1',
+              city: 'myCity',
+              contactName: 'myContactName',
+              email: 'myEmail',
+              id: 123,
+              links: {
+                self: 'mySelf'
+              },
+              personalDataRemoved: false,
+              phoneNumber: 'myPhoneNumber',
+              postcode: 'myPostcode'
+            }
+          ],
+          description: 'myDescription',
+          dunsNumber: 'myDunsNumber',
+          id: 234,
+          links: {
+            self: 'mySelf'
+          },
+          name: 'myName',
+          organisationSize: 'myOrganisationSize',
+          registeredName: 'myRegisteredName',
+          registrationCountry: 'myRegistrationCountry',
+          service_counts: {
+            'serviceCount': 345
+          },
+          tradingStatus: 'myTradingStatus',
+          vatNumber: 'vatNumber'
+        }
+      });
+    });
+  });
+
+  describe('getSupplierFramework', () => {
+    const supplierId = 'supplierId-1234';
+    const path = `/suppliers/${supplierId}/frameworks/g-cloud-13`;
+
+    it('calls the get g-cloud suppliers endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, {
+        frameworkInterest: {
+          agreedVariations: {},
+          agreementDetails: {
+            frameworkAgreementVersion: 'myFrameworkAgreementVersion',
+            signerName: 'mySignerName',
+            signerRole: 'mySignerRole',
+            uploaderUserEmail: 'myUploaderUserEmail',
+            uploaderUserId: 123,
+            uploaderUserName: 'myUploaderUserName'
+          },
+          agreementId: 'myAgreementId',
+          agreementPath: null,
+          agreementReturned: true,
+          agreementReturnedAt: 'myAgreementReturnedAt',
+          agreementStatus: 'myAgreementStatus',
+          allowDeclarationReuse: 'myAllowDeclarationReuse',
+          applicationCompanyDetailsConfirmed: true,
+          countersigned: true,
+          countersignedAt: 'myCountersignedAt',
+          countersignedDetails: {
+            approvedByUserEmail: 'myApprovedByUserEmail',
+            approvedByUserId: 234,
+            approvedByUserName: 'myApprovedByUserName',
+            countersignerName: 'myCountersignerName',
+            countersignerRole: 'myCountersignerRole'
+          },
+          countersignedPath: 'myCountersignedPath',
+          declaration: {
+            declaration: true
+          },
+          frameworkFamily: 'myFrameworkFamily',
+          frameworkFramework: 'myFrameworkFramework',
+          frameworkSlug: 'myFrameworkSlug',
+          onFramework: true,
+          prefillDeclarationFromFrameworkSlug: 'myPrefillDeclarationFromFrameworkSlug',
+          supplierId: 345,
+          supplierName: 'mySupplierName'
+        }
+      });
+
+      const findSupplierFrameworkResult = await serviceAPI.getSupplierFramework(supplierId) as FetchResultOK<GCloudSupplierFramework>;
+
+      expect(findSupplierFrameworkResult.status).to.eq(FetchResultStatus.OK);
+      expect(findSupplierFrameworkResult.data).to.eql({
+        frameworkInterest: {
+          agreedVariations: {},
+          agreementDetails: {
+            frameworkAgreementVersion: 'myFrameworkAgreementVersion',
+            signerName: 'mySignerName',
+            signerRole: 'mySignerRole',
+            uploaderUserEmail: 'myUploaderUserEmail',
+            uploaderUserId: 123,
+            uploaderUserName: 'myUploaderUserName'
+          },
+          agreementId: 'myAgreementId',
+          agreementPath: null,
+          agreementReturned: true,
+          agreementReturnedAt: 'myAgreementReturnedAt',
+          agreementStatus: 'myAgreementStatus',
+          allowDeclarationReuse: 'myAllowDeclarationReuse',
+          applicationCompanyDetailsConfirmed: true,
+          countersigned: true,
+          countersignedAt: 'myCountersignedAt',
+          countersignedDetails: {
+            approvedByUserEmail: 'myApprovedByUserEmail',
+            approvedByUserId: 234,
+            approvedByUserName: 'myApprovedByUserName',
+            countersignerName: 'myCountersignerName',
+            countersignerRole: 'myCountersignerRole'
+          },
+          countersignedPath: 'myCountersignedPath',
+          declaration: {
+            declaration: true
+          },
+          frameworkFamily: 'myFrameworkFamily',
+          frameworkFramework: 'myFrameworkFramework',
+          frameworkSlug: 'myFrameworkSlug',
+          onFramework: true,
+          prefillDeclarationFromFrameworkSlug: 'myPrefillDeclarationFromFrameworkSlug',
+          supplierId: 345,
+          supplierName: 'mySupplierName'
+        }
+      });
+    });
+  });
+});

--- a/src/test/unit/services/gCloud/supplier/api.test.ts
+++ b/src/test/unit/services/gCloud/supplier/api.test.ts
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
+import { supplierAPI } from 'main/services/gCloud/supplier/api';
+import { GCloudFilters } from 'main/services/types/gCloud/supplier/api';
+
+describe('G-Cloud Supplier API helpers', () => {
+  const baseURL = process.env.GCLOUD_SUPPLIER_API_URL;
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.GCLOUD_TOKEN}`
+  };
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('getGCloudFilters', () => {
+    const path = '/g-cloud-filters';
+
+    it('calls the get g cloud endpoint with the correct url (with no query params) and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, {
+        lot: {
+          column: {
+            filters: [
+              {
+                id: 'myId',
+                label: 'myLabel',
+                name: 'myName',
+                value: 'myValue'
+              }
+            ],
+            label: 'Column',
+            slug: 'Slug'
+          }
+        }
+      });
+
+      const gCloudFiltersResult = await supplierAPI.getGCloudFilters(undefined, undefined, undefined) as FetchResultOK<GCloudFilters>;
+
+      expect(gCloudFiltersResult.status).to.eq(FetchResultStatus.OK);
+      expect(gCloudFiltersResult.data).to.eql({
+        lot: {
+          column: {
+            filters: [
+              {
+                id: 'myId',
+                label: 'myLabel',
+                name: 'myName',
+                value: 'myValue'
+              }
+            ],
+            label: 'Column',
+            slug: 'Slug'
+          }
+        }
+      });
+    });
+
+    it('calls the get g cloud endpoint with the correct url (with some query params) and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `${path}?lot=lotParams&parentCategory=parentCategoryParams`,
+        headers: headers
+      }).reply(200, {
+        lot: {
+          column: {
+            filters: [
+              {
+                id: 'myId',
+                label: 'myLabel',
+                name: 'myName',
+                value: 'myValue'
+              }
+            ],
+            label: 'Column',
+            slug: 'Slug'
+          }
+        }
+      });
+
+      const gCloudFiltersResult = await supplierAPI.getGCloudFilters('lotParams', undefined, 'parentCategoryParams') as FetchResultOK<GCloudFilters>;
+
+      expect(gCloudFiltersResult.status).to.eq(FetchResultStatus.OK);
+      expect(gCloudFiltersResult.data).to.eql({
+        lot: {
+          column: {
+            filters: [
+              {
+                id: 'myId',
+                label: 'myLabel',
+                name: 'myName',
+                value: 'myValue'
+              }
+            ],
+            label: 'Column',
+            slug: 'Slug'
+          }
+        }
+      });
+    });
+
+    it('calls the get g cloud endpoint with the correct url (with all query params) and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `${path}?lot=lotParams&serviceCategories=serviceCategoriesParams&parentCategory=parentCategoryParams`,
+        headers: headers
+      }).reply(200, {
+        lot: {
+          column: {
+            filters: [
+              {
+                id: 'myId',
+                label: 'myLabel',
+                name: 'myName',
+                value: 'myValue'
+              }
+            ],
+            label: 'Column',
+            slug: 'Slug'
+          }
+        }
+      });
+
+      const gCloudFiltersResult = await supplierAPI.getGCloudFilters('lotParams', 'serviceCategoriesParams', 'parentCategoryParams') as FetchResultOK<GCloudFilters>;
+
+      expect(gCloudFiltersResult.status).to.eq(FetchResultStatus.OK);
+      expect(gCloudFiltersResult.data).to.eql({
+        lot: {
+          column: {
+            filters: [
+              {
+                id: 'myId',
+                label: 'myLabel',
+                name: 'myName',
+                value: 'myValue'
+              }
+            ],
+            label: 'Column',
+            slug: 'Slug'
+          }
+        }
+      });
+    });
+  });
+});

--- a/src/test/unit/services/helpers/api.test.ts
+++ b/src/test/unit/services/helpers/api.test.ts
@@ -1,0 +1,458 @@
+import { expect } from 'chai';
+import { genericFecthGet, genericFecthPost } from 'main/services/helpers/api';
+import { FetchError, FetchTimeoutError } from 'main/services/helpers/errors';
+import { FetchResultError, FetchResultOK, FetchResultStatus, HTTPMethod } from 'main/services/types/helpers/api';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+
+type GenericData = {
+  ok: boolean
+}
+
+describe('fecth helpers', () => {
+  const baseURL = 'http://example.com';
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('generic fecth get', () => {
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    describe('when the response is 200', () => {
+      it('calls get with the formatted URL and the provided headers', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          path: path,
+          headers: headers
+        }).reply(200, { ok: true });
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers
+        ) as FetchResultOK<GenericData>;
+
+        expect(genericFecthGetResult.status).to.eq(FetchResultStatus.OK);
+        expect(genericFecthGetResult.data).to.eql({ ok: true });
+      });
+
+      it('calls get with the formatted URL and the provided headers when there is an id', async () => {
+        const path = '/test/:test-id';
+
+        mockPool.intercept({
+          path: '/test/test-1234',
+          headers: headers
+        }).reply(200, { ok: true });
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path,
+            params: [[':test-id', 'test-1234']]
+          },
+          headers
+        ) as FetchResultOK<GenericData>;
+
+        expect(genericFecthGetResult.status).to.eq(FetchResultStatus.OK);
+        expect(genericFecthGetResult.data).to.eql({ ok: true });
+      });
+
+      it('calls get with the formatted URL and the provided headers when there are query params', async () => {
+        const path = '/test';
+        const queryParams = {
+          myParam: 'myParam'
+        };
+
+        mockPool.intercept({
+          path: '/test?myParam=myParam',
+          headers: headers
+        }).reply(200, { ok: true });
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path,
+            queryParams: queryParams
+          },
+          headers
+        ) as FetchResultOK<GenericData>;
+
+        expect(genericFecthGetResult.status).to.eq(FetchResultStatus.OK);
+        expect(genericFecthGetResult.data).to.eql({ ok: true });
+      });
+
+      it('calls get with the formatted URL and the provided headers when there is an id and query params', async () => {
+        const path = '/test/:test-id';
+        const queryParams = {
+          myParam: 'myParam'
+        };
+
+        mockPool.intercept({
+          path: '/test/test-1234?myParam=myParam',
+          headers: headers
+        }).reply(200, { ok: true });
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path,
+            params: [[':test-id', 'test-1234']],
+            queryParams: queryParams
+          },
+          headers
+        ) as FetchResultOK<GenericData>;
+
+        expect(genericFecthGetResult.status).to.eq(FetchResultStatus.OK);
+        expect(genericFecthGetResult.data).to.eql({ ok: true });
+      });
+
+      it('can unwrap the result', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          path: path,
+          headers: headers
+        }).reply(200, { ok: true });
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers
+        );
+
+        expect(genericFecthGetResult.unwrap()).to.eql({ ok: true });
+      });
+    });
+
+    describe('when the response is not 200', () => {
+      it('returns an error result', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          path: path,
+          headers: headers
+        }).reply(404);
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers
+        ) as FetchResultError;
+
+        expect(genericFecthGetResult.status).to.eq(FetchResultStatus.ERROR);
+        expect(genericFecthGetResult.error).to.eql(new FetchError(HTTPMethod.GET, baseURL + path, 404));
+      });
+    });
+
+    describe('when an error is thrown', () => {
+      it('returns an error result', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          path: path,
+          headers: headers
+        }).reply(200, '> INVALID JSON');
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers
+        ) as FetchResultError;
+
+        expect(genericFecthGetResult.status).to.eq(FetchResultStatus.ERROR);
+        expect(genericFecthGetResult.error).to.eql(new SyntaxError('Unexpected token > in JSON at position 0'));
+      });
+
+      it('it throws the error when the result is unwrapped', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          path: path,
+          headers: headers
+        }).reply(200, '> INVALID JSON');
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers
+        );
+
+        expect(genericFecthGetResult.unwrap).to.throw(SyntaxError, 'Unexpected token > in JSON at position 0');
+      });
+    });
+
+    describe('when the request times out', () => {
+      it('returns an error result', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          path: path,
+          headers: headers,
+        }).reply(200, { ok: true })
+          .delay(1000);
+
+        const genericFecthGetResult = await genericFecthGet(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers,
+          10
+        ) as FetchResultError;
+
+        expect(genericFecthGetResult.status).to.eq(FetchResultStatus.ERROR);
+        expect(genericFecthGetResult.error).to.eql(new FetchTimeoutError(HTTPMethod.GET, baseURL + path, 10));
+      });
+    });
+  });
+
+  describe('generic fecth post', () => {
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+    const body = {
+      data: 'myData'
+    };
+
+    describe('when the response is 200', () => {
+      it('calls get with the formatted URL and the provided headers', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          method: 'POST',
+          path: path,
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(200, { ok: true });
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers,
+          body
+        ) as FetchResultOK<GenericData>;
+
+        expect(genericFecthPostResult.status).to.eq(FetchResultStatus.OK);
+        expect(genericFecthPostResult.data).to.eql({ ok: true });
+      });
+
+      it('calls get with the formatted URL and the provided headers when there is an id', async () => {
+        const path = '/test/:test-id';
+
+        mockPool.intercept({
+          method: 'POST',
+          path: '/test/test-1234',
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(200, { ok: true });
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path,
+            params: [[':test-id', 'test-1234']]
+          },
+          headers,
+          body
+        ) as FetchResultOK<GenericData>;
+
+        expect(genericFecthPostResult.status).to.eq(FetchResultStatus.OK);
+        expect(genericFecthPostResult.data).to.eql({ ok: true });
+      });
+
+      it('calls get with the formatted URL and the provided headers when there are query params', async () => {
+        const path = '/test';
+        const queryParams = {
+          myParam: 'myParam'
+        };
+
+        mockPool.intercept({
+          method: 'POST',
+          path: '/test?myParam=myParam',
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(200, { ok: true });
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path,
+            queryParams: queryParams
+          },
+          headers,
+          body
+        ) as FetchResultOK<GenericData>;
+
+        expect(genericFecthPostResult.status).to.eq(FetchResultStatus.OK);
+        expect(genericFecthPostResult.data).to.eql({ ok: true });
+      });
+
+      it('calls get with the formatted URL and the provided headers when there is an id and query params', async () => {
+        const path = '/test/:test-id';
+        const queryParams = {
+          myParam: 'myParam'
+        };
+
+        mockPool.intercept({
+          method: 'POST',
+          path: '/test/test-1234?myParam=myParam',
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(200, { ok: true });
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path,
+            params: [[':test-id', 'test-1234']],
+            queryParams: queryParams
+          },
+          headers,
+          body
+        ) as FetchResultOK<GenericData>;
+
+        expect(genericFecthPostResult.status).to.eq(FetchResultStatus.OK);
+        expect(genericFecthPostResult.data).to.eql({ ok: true });
+      });
+
+      it('can unwrap the result', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          method: 'POST',
+          path: path,
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(200, { ok: true });
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers,
+          body
+        );
+
+        expect(genericFecthPostResult.unwrap()).to.eql({ ok: true });
+      });
+    });
+
+    describe('when the response is not 200', () => {
+      it('returns an error result', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          method: 'POST',
+          path: path,
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(403);
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers,
+          body
+        ) as FetchResultError;
+
+        expect(genericFecthPostResult.status).to.eq(FetchResultStatus.ERROR);
+        expect(genericFecthPostResult.error).to.eql(new FetchError(HTTPMethod.POST, baseURL + path, 403));
+      });
+    });
+
+    describe('when an error is thrown', () => {
+      it('returns an error result', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          method: 'POST',
+          path: path,
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(200, '> INVALID JSON');
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers,
+          body
+        ) as FetchResultError;
+
+        expect(genericFecthPostResult.status).to.eq(FetchResultStatus.ERROR);
+        expect(genericFecthPostResult.error).to.eql(new SyntaxError('Unexpected token > in JSON at position 0'));
+      });
+
+      it('it throws the error when the result is unwrapped', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          method: 'POST',
+          path: path,
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(200, '> INVALID JSON');
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers,
+          body
+        );
+
+        expect(genericFecthPostResult.unwrap).to.throw(SyntaxError, 'Unexpected token > in JSON at position 0');
+      });
+    });
+
+    describe('when the request times out', () => {
+      it('returns an error result', async () => {
+        const path = '/test';
+
+        mockPool.intercept({
+          method: 'POST',
+          path: path,
+          headers: headers,
+          body: JSON.stringify(body)
+        }).reply(200, { ok: true })
+          .delay(1000);
+
+        const genericFecthPostResult = await genericFecthPost(
+          {
+            baseURL: baseURL,
+            path: path
+          },
+          headers,
+          body,
+          10
+        ) as FetchResultError;
+
+        expect(genericFecthPostResult.status).to.eq(FetchResultStatus.ERROR);
+        expect(genericFecthPostResult.error).to.eql(new FetchTimeoutError(HTTPMethod.POST, baseURL + path, 10));
+      });
+    });
+  });
+});

--- a/src/test/unit/services/helpers/errors.test.ts
+++ b/src/test/unit/services/helpers/errors.test.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { FetchError } from 'main/services/helpers/errors';
+import { HTTPMethod } from 'main/services/types/helpers/api';
+
+describe('Service API Errors', () => {
+  it ('returns the correct message for FetchError with get', () => {
+    const error = new FetchError(HTTPMethod.GET, 'http://example.com/test', 404);
+
+    expect(error.message).to.eq('The call GET http://example.com/test returned an unexpected status: 404');
+  });
+
+  it ('returns the correct message for FetchError with POST', () => {
+    const error = new FetchError(HTTPMethod.POST, 'http://example.com/test', 403);
+
+    expect(error.message).to.eq('The call POST http://example.com/test returned an unexpected status: 403');
+  });
+});

--- a/src/test/unit/services/helpers/url.test.ts
+++ b/src/test/unit/services/helpers/url.test.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import { formatURL } from 'main/services/helpers/url';
+
+describe('URL helpers', () => {
+  const baseURL = 'http://example.com';
+
+  describe('formatURL', () => {
+    it('returns the base url with the path when no other params are passed', () => {
+      const path = '/test';
+
+      expect(formatURL({ baseURL, path })).to.eq('http://example.com/test');
+    });
+
+    it('replaces the ids when id params are passed', () => {
+      const path = '/test/:test-id/user/:user-id';
+
+      expect(formatURL({ baseURL, path, params: [[':test-id', 'test-1234'], [':user-id', 'user-1234']] })).to.eq('http://example.com/test/test-1234/user/user-1234');
+    });
+
+    it('only replaces the params if they are present', () => {
+      const path = '/test/:test-id/user/:user-id';
+
+      expect(formatURL({ baseURL, path, params: [[':user-id', 'user-1234']] })).to.eq('http://example.com/test/:test-id/user/user-1234');
+    });
+
+    it('adds the query parameters', () => {
+      const path = '/test';
+      const queryParams = {
+        test: 'test',
+        myParam: 'myParam'
+      };
+
+      expect(formatURL({ baseURL, path, queryParams })).to.eq('http://example.com/test?test=test&myParam=myParam');
+    });
+
+    it('works when all params are passed', () => {
+      const path = '/test/:test-id/user/:user-id';
+      const queryParams = {
+        test: 'test',
+        myParam: 'myParam'
+      };
+
+      expect(formatURL({ baseURL, path, params: [[':test-id', 'test-1234'], [':user-id', 'user-1234']], queryParams })).to.eq('http://example.com/test/test-1234/user/user-1234?test=test&myParam=myParam');
+    });
+  });
+});

--- a/src/test/unit/services/publicProcurementGateway/oAuth/api.test.ts
+++ b/src/test/unit/services/publicProcurementGateway/oAuth/api.test.ts
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+import { oAuthAPI } from 'main/services/publicProcurementGateway/oAuth/api';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { AuthCredentials, RefreshData } from 'main/services/types/publicProcurementGateway/oAuth/api';
+import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
+
+describe('OAuth API helpers', () => {
+  const baseURL = process.env.AUTH_SERVER_BASE_URL;
+  const clientId = process.env.AUTH_SERVER_CLIENT_ID;
+  const clientSecret = process.env.AUTH_SERVER_CLIENT_SECRET;
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('postRefreshToken', () => {
+    it('calls the post refresh token endpoint with the correct url and headers', async () => {
+      const authCredentials: AuthCredentials = {
+        refresh_token: 'myRefreshToken',
+        code: 'myCode',
+        redirect_uri: 'myRedirectUri',
+        response_type: 'myResponseType'
+      };
+      mockPool.intercept({
+        method: 'POST',
+        path: '/security/token',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          client_secret: clientSecret,
+          grant_type: 'refresh_token',
+          ...authCredentials
+        })
+      }).reply(200, { access_token: 'myAccessToken', session_state: 'mySessionState', refresh_token: 'myRefreshToken' });
+
+      const refreshTokenResult = await oAuthAPI.postRefreshToken(authCredentials) as FetchResultOK<RefreshData>;
+
+      expect(refreshTokenResult.status).to.eq(FetchResultStatus.OK);
+      expect(refreshTokenResult.data).to.eql({ access_token: 'myAccessToken', session_state: 'mySessionState', refresh_token: 'myRefreshToken' });
+    });
+
+    it('calls the post refresh token endpoint with the correct url and headers when there are less auth credentials', async () => {
+      const authCredentials: AuthCredentials = {
+        refresh_token: 'myRefreshToken',
+      };
+      mockPool.intercept({
+        method: 'POST',
+        path: '/security/token',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          client_secret: clientSecret,
+          grant_type: 'refresh_token',
+          ...authCredentials
+        })
+      }).reply(200, { access_token: 'myAccessToken', session_state: 'mySessionState', refresh_token: 'myRefreshToken' });
+
+      const refreshTokenResult = await oAuthAPI.postRefreshToken(authCredentials) as FetchResultOK<RefreshData>;
+
+      expect(refreshTokenResult.status).to.eq(FetchResultStatus.OK);
+      expect(refreshTokenResult.data).to.eql({ access_token: 'myAccessToken', session_state: 'mySessionState', refresh_token: 'myRefreshToken' });
+    });
+  });
+
+  describe('postValidateToken', () => {
+    it('calls the post refresh token endpoint with the correct url and headers', async () => {
+      const accessToken = 'myAccessToken';
+      mockPool.intercept({
+        method: 'POST',
+        path: `/security/tokens/validation?client-id=${clientId}`,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`
+        },
+      }).reply(200, 'true');
+
+      const validateTokenResult = await oAuthAPI.postValidateToken(accessToken) as FetchResultOK<boolean>;
+
+      expect(validateTokenResult.status).to.eq(FetchResultStatus.OK);
+      expect(validateTokenResult.data).to.eq(true);
+    });
+  });
+});

--- a/src/test/unit/services/publicProcurementGateway/oAuth/url.test.ts
+++ b/src/test/unit/services/publicProcurementGateway/oAuth/url.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { oAuthURL } from 'main/services/publicProcurementGateway/oAuth/url';
+import { Request } from 'express';
+
+describe('OAuth URL helpers', () => {
+  describe('login', () => {
+    it('returns the login URL when there is no request', () => {
+
+      expect(oAuthURL.login()).to.eq('http://auth-server.com/security/authorize?response_type=code&scope=openid+profile+FirstName+LastName++email++offline_access&client_id=auth-server-client-id&redirect_uri=http%3A%2F%2Fcas.com%2Freceiver');
+    });
+
+    it('returns the login URL when there is a request but no supplier_qa_url', () => {
+      const req = { session: {} } as Request;
+
+      expect(oAuthURL.login(req)).to.eq('http://auth-server.com/security/authorize?response_type=code&scope=openid+profile+FirstName+LastName++email++offline_access&client_id=auth-server-client-id&redirect_uri=http%3A%2F%2Fcas.com%2Freceiver');
+    });
+
+    it('returns the login URL with the urlId when there is a request and supplier_qa_url', () => {
+      // TODO: Remove cast to unknown
+      const req = { session: { supplier_qa_url: 'http://supplier-qa.com' } } as unknown as Request;
+
+      expect(oAuthURL.login(req)).to.eq('http://auth-server.com/security/authorize?response_type=code&scope=openid+profile+FirstName+LastName++email++offline_access&client_id=auth-server-client-id&redirect_uri=http%3A%2F%2Fcas.com%2Freceiver&urlId=http%3A%2F%2Fsupplier-qa.com');
+    });
+  });
+
+  describe('logout', () => {
+    it('returns the logout URL', () => {
+
+      expect(oAuthURL.logout()).to.eq('http://auth-server.com/security/log-out?client-id=auth-server-client-id&redirect-uri=http%3A%2F%2Fcas.com%2Flogout');
+    });
+  });
+});

--- a/src/test/unit/services/publicProcurementGateway/organisation/api.test.ts
+++ b/src/test/unit/services/publicProcurementGateway/organisation/api.test.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { organisationAPI } from 'main/services/publicProcurementGateway/organisation/api';
+import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
+import { Organisation, OrganisationUsers, UserProfile } from 'main/services/types/publicProcurementGateway/organisation/api';
+
+describe('Organisation API helpers', () => {
+  const baseURL = process.env.CONCLAVE_WRAPPER_API_BASE_URL;
+  const headers = {
+    'Content-Type': 'application/json',
+    'x-api-key': process.env.CONCLAVE_WRAPPER_API_KEY
+  };
+  let mockPool: Interceptable;
+
+  beforeEach(() => {
+    const mockAgent = new MockAgent();
+    mockPool = mockAgent.get(baseURL);
+    setGlobalDispatcher(mockAgent);
+  });
+
+  describe('getOrganisation', () => {
+    const orgId = 'org-1234';
+    const path = `/organisation-profiles/${orgId}`;
+
+    it('calls the get organisation endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, { identifier: { legalName: 'myOrg' } });
+
+      const findOrganisationResult = await organisationAPI.getOrganisation(orgId) as FetchResultOK<Organisation>;
+
+      expect(findOrganisationResult.status).to.eq(FetchResultStatus.OK);
+      expect(findOrganisationResult.data).to.eql({ identifier: { legalName: 'myOrg' } });
+    });
+
+    it('calls the get organisation endpoint with the correct url, headers and query params', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `${path}?my_param=myParam`,
+        headers: headers
+      }).reply(200, { identifier: { legalName: 'myOrg' } });
+
+      const findOrganisationResult = await organisationAPI.getOrganisation(orgId, { my_param: 'myParam' }) as FetchResultOK<Organisation>;
+
+      expect(findOrganisationResult.status).to.eq(FetchResultStatus.OK);
+      expect(findOrganisationResult.data).to.eql({ identifier: { legalName: 'myOrg' } });
+    });
+  });
+
+  describe('getOrganisationUsers', () => {
+    const orgId = 'org-1234';
+    const path = `/organisation-profiles/${orgId}/users`;
+
+    it('calls the get organisation users endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, { pageCount: 1, userList: [{ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }] });
+
+      const getOrganisationUsersResult = await organisationAPI.getOrganisationUsers(orgId) as FetchResultOK<OrganisationUsers>;
+
+      expect(getOrganisationUsersResult.status).to.eq(FetchResultStatus.OK);
+      expect(getOrganisationUsersResult.data).to.eql({ pageCount: 1, userList: [{ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }] });
+    });
+
+    it('calls the get organisation users endpoint with the correct url, headers and query params', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `${path}?my_param=myParam`,
+        headers: headers
+      }).reply(200, { pageCount: 1, userList: [{ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }] });
+
+      const getOrganisationUsersResult = await organisationAPI.getOrganisationUsers(orgId, { my_param: 'myParam' }) as FetchResultOK<OrganisationUsers>;
+
+      expect(getOrganisationUsersResult.status).to.eq(FetchResultStatus.OK);
+      expect(getOrganisationUsersResult.data).to.eql({ pageCount: 1, userList: [{ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }] });
+    });
+  });
+
+  describe('getUserProfiles', () => {
+    const userId = 'user-1234';
+    const path = `/user-profiles?user-Id=${userId}`;
+
+    it('calls the get user profile endpoint with the correct url and headers', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: path,
+        headers: headers
+      }).reply(200, { userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' });
+
+      const findUserProfileResult = await organisationAPI.getUserProfiles(userId) as FetchResultOK<UserProfile>;
+
+      expect(findUserProfileResult.status).to.eq(FetchResultStatus.OK);
+      expect(findUserProfileResult.data).to.eql({ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' });
+    });
+
+    it('calls the get user profile endpoint with the correct url, headers and query params', async () => {
+      mockPool.intercept({
+        method: 'GET',
+        path: `${path}&my_param=myParam`,
+        headers: headers
+      }).reply(200, { userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' });
+
+      const findUserProfileResult = await organisationAPI.getUserProfiles(userId, { my_param: 'myParam' }) as FetchResultOK<UserProfile>;
+
+      expect(findUserProfileResult.status).to.eq(FetchResultStatus.OK);
+      expect(findUserProfileResult.data).to.eql({ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' });
+    });
+  });
+});


### PR DESCRIPTION
### JIRA link

[CAS-1340](https://crowncommercialservice.atlassian.net/browse/CAS-1340)

### Change description

I have created services (code module) that can be used to handle API requests to the following services:

- Public Procurement Gateway
  - OAuth
  - Organisation
- Agreement Service
- G-Cloud
  - Service
  - Supplier
  - Search
- Bank Holidays
- Content Service

This means we won’t have to write the path we want to query in every instance of the code which should make it a lot more manageable.

I’ve also added tests for the endpoint to make sure the helpers I created do what we expect.

I also plan on doing this for the Tenders API but as it is quite large I want to do it separately. I have not done anything for the Logger instance as I am looking to remove that in the future. I have also not integrated any of the services with the app yet as I want to do that separately in the future.

### Work checklist

- [x] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


[CAS-1340]: https://crowncommercialservice.atlassian.net/browse/CAS-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ