### PR TITLE
CAS-1586 - Cache the static agreement service endpoints

### DIFF
--- a/src/main/services/agreementsService/api.ts
+++ b/src/main/services/agreementsService/api.ts
@@ -19,6 +19,9 @@ const endPoints: EndPoints = {
   agreementLotEventTypes: '/agreements/:agreement-id/lots/:lot-id/event-types'
 };
 
+// This data is static so we can Cache for an hour 
+const agreementServiceCacheLength = 3600;
+
 // GET /agreements/:agreement-id
 const getAgreement = async (agreementId: string): Promise<FetchResult<AgreementDetail>> => {
   return genericFecthGet<AgreementDetail>(
@@ -29,7 +32,11 @@ const getAgreement = async (agreementId: string): Promise<FetchResult<AgreementD
         [':agreement-id', agreementId]
       ]
     },
-    headers
+    headers,
+    {
+      key: `get_agreements_${agreementId}`,
+      seconds: agreementServiceCacheLength
+    }
   );
 };
 
@@ -43,7 +50,11 @@ const getAgreementLots = async (agreementId: string): Promise<FetchResult<LotDet
         [':agreement-id', agreementId]
       ]
     },
-    headers
+    headers,
+    {
+      key: `get_agreements_${agreementId}_lots`,
+      seconds: agreementServiceCacheLength
+    }
   );
 };
 
@@ -58,7 +69,11 @@ const getAgreementLot = async (agreementId: string, lotId: string): Promise<Fetc
         [':lot-id', lotId]
       ]
     },
-    headers
+    headers,
+    {
+      key: `get_agreements_${agreementId}_lots_${lotId}`,
+      seconds: agreementServiceCacheLength
+    }
   );
 };
 
@@ -73,11 +88,15 @@ const getAgreementLotSuppliers = async (agreementId: string, lotId: string): Pro
         [':lot-id', lotId]
       ]
     },
-    headers
+    headers,
+    {
+      key: `get_agreements_${agreementId}_lots_${lotId}_suppliers`,
+      seconds: 900
+    }
   );
 };
 
-// GET /agreements:agreement-id/lots/:lot-id/suppliers
+// GET /agreements:agreement-id/lots/:lot-id/event-types
 const getAgreementLotEventTypes = async (agreementId: string, lotId: string): Promise<FetchResult<AgreementLotEventType[]>> => {
   return genericFecthGet<AgreementLotEventType[]>(
     {
@@ -88,7 +107,11 @@ const getAgreementLotEventTypes = async (agreementId: string, lotId: string): Pr
         [':lot-id', lotId]
       ]
     },
-    headers
+    headers,
+    {
+      key: `get_agreements_${agreementId}_lots_${lotId}_event_types`,
+      seconds: agreementServiceCacheLength
+    }
   );
 };
 

--- a/src/main/services/contentService/api.ts
+++ b/src/main/services/contentService/api.ts
@@ -23,6 +23,7 @@ const getMenu = async (menuId: string): Promise<FetchResult<ContentServiceMenu>>
     {
       'Content-Type': 'application/json',
     },
+    undefined,
     timeout
   );
 };

--- a/src/main/services/types/helpers/api.ts
+++ b/src/main/services/types/helpers/api.ts
@@ -3,6 +3,11 @@ enum HTTPMethod {
   POST = 'POST'
 }
 
+type CacheOptions = {
+  key: string
+  seconds: number
+}
+
 interface FetchRequestInit extends Omit<RequestInit, 'method'> {
   method: HTTPMethod
 }
@@ -28,4 +33,4 @@ type FetchResult<T> = BaseFetchResult<T> & {
   unwrap: () => T
 }
 
-export { HTTPMethod, FetchRequestInit, BaseFetchResult, FetchResult, FetchResultStatus, FetchResultOK, FetchResultError };
+export { HTTPMethod, CacheOptions, FetchRequestInit, BaseFetchResult, FetchResult, FetchResultStatus, FetchResultOK, FetchResultError };

--- a/src/test/unit/services/agreementsService/api.test.ts
+++ b/src/test/unit/services/agreementsService/api.test.ts
@@ -1,18 +1,23 @@
+import Sinon from 'sinon';
 import { AgreementDetail } from '@common/middlewares/models/agreement-detail';
 import { LotDetail } from '@common/middlewares/models/lot-detail';
 import { LotSupplier } from '@common/middlewares/models/lot-supplier';
+import { AgreementLotEventType } from 'main/services/types/agreementsService/api';
 import { expect } from 'chai';
 import { agreementsServiceAPI } from 'main/services/agreementsService/api';
-import { AgreementLotEventType } from 'main/services/types/agreementsService/api';
 import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
 import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
+import { assertRedisCalls, assertRedisCallsWithCache, creatRedisMockSpy } from 'test/utils/mocks/redis';
 
 describe('Agrements Service API helpers', () => {
+  const mock = Sinon.createSandbox();
+
   const baseURL = process.env.AGREEMENTS_SERVICE_API_URL;
   const headers = {
     'Content-Type': 'application/json',
   };
   const agreementId = 'agreementId-1234';
+
   let mockPool: Interceptable;
 
   beforeEach(() => {
@@ -21,178 +26,237 @@ describe('Agrements Service API helpers', () => {
     setGlobalDispatcher(mockAgent);
   });
 
+  afterEach(() => {
+    mock.restore();
+  });
+
   describe('getAgreement', () => {
-    it('calls the get agreement endpoint with the correct url and headers', async () => {
-      mockPool.intercept({
-        method: 'GET',
-        path: `/agreements/${agreementId}`,
-        headers: headers
-      }).reply(200, { name: 'myName', endDate: 'myEndDate' });
+    const data = { name: 'myName', endDate: 'myEndDate' };
 
-      const findAgreementResult = await agreementsServiceAPI.getAgreement(agreementId) as FetchResultOK<AgreementDetail>;
+    describe('when no data is cached', () => {
+      it('calls the get agreement endpoint with the correct url and headers', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock);
 
-      expect(findAgreementResult.status).to.eq(FetchResultStatus.OK);
-      expect(findAgreementResult.data).to.eql({ name: 'myName', endDate: 'myEndDate' });
+        mockPool.intercept({
+          method: 'GET',
+          path: `/agreements/${agreementId}`,
+          headers: headers
+        }).reply(200, data);
+
+        const findAgreementResult = await agreementsServiceAPI.getAgreement(agreementId) as FetchResultOK<AgreementDetail>;
+
+        expect(findAgreementResult.status).to.eq(FetchResultStatus.OK);
+        expect(findAgreementResult.data).to.eql(data);
+
+        assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234', data, 3600);
+      });
+    });
+
+    describe('when data is cached', () => {
+      it('does not call the get agreement endpoint but still returns the data', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+
+        const findAgreementResult = await agreementsServiceAPI.getAgreement(agreementId) as FetchResultOK<AgreementDetail>;
+
+        expect(findAgreementResult.status).to.eq(FetchResultStatus.OK);
+        expect(findAgreementResult.data).to.eql(data);
+
+        assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234');
+      });
     });
   });
 
   describe('getAgreementLots', () => {
-    it('calls the get agreement lots endpoint with the correct url and headers', async () => {
-      mockPool.intercept({
-        method: 'GET',
-        path: `/agreements/${agreementId}/lots`,
-        headers: headers
-      }).reply(200, [
-        {
-          number: 'myNumber',
-          name: 'myName',
-          startDate: 'myStartDate',
-          endDate: 'myEndDate',
-          description: 'myDescription',
-          suppliers: 'mySuppliers',
-          type: 'myType',
-          routesToMarket: 'myRoutesToMarket',
-          sectors: ['sectors'],
-          relatedAgreementLots: [{}],
-          rules: [{}]
-        }
-      ]);
+    const data = [
+      {
+        number: 'myNumber',
+        name: 'myName',
+        startDate: 'myStartDate',
+        endDate: 'myEndDate',
+        description: 'myDescription',
+        suppliers: 'mySuppliers',
+        type: 'myType',
+        routesToMarket: 'myRoutesToMarket',
+        sectors: ['sectors'],
+        relatedAgreementLots: [{}],
+        rules: [{}]
+      }
+    ];
 
-      const getAgreementLotsResult = await agreementsServiceAPI.getAgreementLots(agreementId) as FetchResultOK<LotDetail[]>;
+    describe('when no data is cached', () => {
+      it('calls the get agreement lots endpoint with the correct url and headers', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock);
 
-      expect(getAgreementLotsResult.status).to.eq(FetchResultStatus.OK);
-      expect(getAgreementLotsResult.data).to.eql([
-        {
-          number: 'myNumber',
-          name: 'myName',
-          startDate: 'myStartDate',
-          endDate: 'myEndDate',
-          description: 'myDescription',
-          suppliers: 'mySuppliers',
-          type: 'myType',
-          routesToMarket: 'myRoutesToMarket',
-          sectors: ['sectors'],
-          relatedAgreementLots: [{}],
-          rules: [{}]
-        }
-      ]);
+        mockPool.intercept({
+          method: 'GET',
+          path: `/agreements/${agreementId}/lots`,
+          headers: headers
+        }).reply(200, data);
+
+        const getAgreementLotsResult = await agreementsServiceAPI.getAgreementLots(agreementId) as FetchResultOK<LotDetail[]>;
+
+        expect(getAgreementLotsResult.status).to.eq(FetchResultStatus.OK);
+        expect(getAgreementLotsResult.data).to.eql(data);
+
+        assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots', data, 3600);
+      });
+    });
+
+    describe('when data is cached', () => {
+      it('does not call the get agreement lots endpoint but still returns the data', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+
+        const getAgreementLotsResult = await agreementsServiceAPI.getAgreementLots(agreementId) as FetchResultOK<LotDetail[]>;
+
+        expect(getAgreementLotsResult.status).to.eq(FetchResultStatus.OK);
+        expect(getAgreementLotsResult.data).to.eql(data);
+
+        assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots');
+      });
     });
   });
 
   describe('getAgreementLot', () => {
-    it('calls the get agreement lot endpoint with the correct url and headers', async () => {
-      const lotId = 'lotId-1234';
+    const lotId = 'lotId-1234';
+    const data = {
+      number: 'myNumber',
+      name: 'myName',
+      startDate: 'myStartDate',
+      endDate: 'myEndDate',
+      description: 'myDescription',
+      suppliers: 'mySuppliers',
+      type: 'myType',
+      routesToMarket: 'myRoutesToMarket',
+      sectors: ['sectors'],
+      relatedAgreementLots: [{}],
+      rules: [{}]
+    };
 
-      mockPool.intercept({
-        method: 'GET',
-        path: `/agreements/${agreementId}/lots/${lotId}`,
-        headers: headers
-      }).reply(200, {
-        number: 'myNumber',
-        name: 'myName',
-        startDate: 'myStartDate',
-        endDate: 'myEndDate',
-        description: 'myDescription',
-        suppliers: 'mySuppliers',
-        type: 'myType',
-        routesToMarket: 'myRoutesToMarket',
-        sectors: ['sectors'],
-        relatedAgreementLots: [{}],
-        rules: [{}]
+    describe('when no data is cached', () => {
+      it('calls the get agreement lot endpoint with the correct url and headers', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock);
+
+        mockPool.intercept({
+          method: 'GET',
+          path: `/agreements/${agreementId}/lots/${lotId}`,
+          headers: headers
+        }).reply(200, data);
+
+        const findAgreementLotResult = await agreementsServiceAPI.getAgreementLot(agreementId, lotId) as FetchResultOK<LotDetail>;
+
+        expect(findAgreementLotResult.status).to.eq(FetchResultStatus.OK);
+        expect(findAgreementLotResult.data).to.eql(data);
+
+        assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234', data, 3600);
       });
+    });
 
-      const findAgreementLotResult = await agreementsServiceAPI.getAgreementLot(agreementId, lotId) as FetchResultOK<LotDetail>;
+    describe('when data is cached', () => {
+      it('does not call the get agreement lot endpoint but still returns the data', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock, data);
 
-      expect(findAgreementLotResult.status).to.eq(FetchResultStatus.OK);
-      expect(findAgreementLotResult.data).to.eql({
-        number: 'myNumber',
-        name: 'myName',
-        startDate: 'myStartDate',
-        endDate: 'myEndDate',
-        description: 'myDescription',
-        suppliers: 'mySuppliers',
-        type: 'myType',
-        routesToMarket: 'myRoutesToMarket',
-        sectors: ['sectors'],
-        relatedAgreementLots: [{}],
-        rules: [{}]
+        const findAgreementLotResult = await agreementsServiceAPI.getAgreementLot(agreementId, lotId) as FetchResultOK<LotDetail>;
+
+        expect(findAgreementLotResult.status).to.eq(FetchResultStatus.OK);
+        expect(findAgreementLotResult.data).to.eql(data);
+
+        assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234');
       });
     });
   });
 
   describe('getAgreementLotSuppliers', () => {
-    it('calls the get agreement lot suppliers endpoint with the correct url and headers', async () => {
-      const lotId = 'lotId-1234';
+    const lotId = 'lotId-1234';
+    const data = [
+      {
+        supplierName: 'mySupplierName',
+        supplierAddress: {
+          streetAddress: 'myStreetAddress',
+          locality: 'myLocality',
+          region: 'myRegion',
+          postalCode: 'myPostalCode',
+          countryName: 'myCountryName',
+          countryCode: 'myCountryCode'
+        },
+        supplierContactName: 'mySupplierContactName',
+        supplierContactEmail: 'mySupplierContactEmail',
+        supplierWebsite: 'mySupplierWebsite',
+        supplierId: 'mySupplierId',
+        supplierOrganisation: 'mySupplierOrganisation',
+        responseState: 'myResponseState',
+        responseDate: 'myResponseDate',
+        score: 'myScore',
+        rank: 'myRank'
+      }
+    ];
 
-      mockPool.intercept({
-        method: 'GET',
-        path: `/agreements/${agreementId}/lots/${lotId}/suppliers`,
-        headers: headers
-      }).reply(200, [
-        {
-          supplierName: 'mySupplierName',
-          supplierAddress: {
-            streetAddress: 'myStreetAddress',
-            locality: 'myLocality',
-            region: 'myRegion',
-            postalCode: 'myPostalCode',
-            countryName: 'myCountryName',
-            countryCode: 'myCountryCode'
-          },
-          supplierContactName: 'mySupplierContactName',
-          supplierContactEmail: 'mySupplierContactEmail',
-          supplierWebsite: 'mySupplierWebsite',
-          supplierId: 'mySupplierId',
-          supplierOrganisation: 'mySupplierOrganisation',
-          responseState: 'myResponseState',
-          responseDate: 'myResponseDate',
-          score: 'myScore',
-          rank: 'myRank'
-        }
-      ]);
+    describe('when no data is cached', () => {
+      it('calls the get agreement lot suppliers endpoint with the correct url and headers', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock);
 
-      const getAgreementLotSuppliersResult = await agreementsServiceAPI.getAgreementLotSuppliers(agreementId, lotId) as FetchResultOK<LotSupplier[]>;
+        mockPool.intercept({
+          method: 'GET',
+          path: `/agreements/${agreementId}/lots/${lotId}/suppliers`,
+          headers: headers
+        }).reply(200, data);
 
-      expect(getAgreementLotSuppliersResult.status).to.eq(FetchResultStatus.OK);
-      expect(getAgreementLotSuppliersResult.data).to.eql([
-        {
-          supplierName: 'mySupplierName',
-          supplierAddress: {
-            streetAddress: 'myStreetAddress',
-            locality: 'myLocality',
-            region: 'myRegion',
-            postalCode: 'myPostalCode',
-            countryName: 'myCountryName',
-            countryCode: 'myCountryCode'
-          },
-          supplierContactName: 'mySupplierContactName',
-          supplierContactEmail: 'mySupplierContactEmail',
-          supplierWebsite: 'mySupplierWebsite',
-          supplierId: 'mySupplierId',
-          supplierOrganisation: 'mySupplierOrganisation',
-          responseState: 'myResponseState',
-          responseDate: 'myResponseDate',
-          score: 'myScore',
-          rank: 'myRank'
-        }
-      ]);
+        const getAgreementLotSuppliersResult = await agreementsServiceAPI.getAgreementLotSuppliers(agreementId, lotId) as FetchResultOK<LotSupplier[]>;
+
+        expect(getAgreementLotSuppliersResult.status).to.eq(FetchResultStatus.OK);
+        expect(getAgreementLotSuppliersResult.data).to.eql(data);
+
+        assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234_suppliers', data, 900);
+      });
+    });
+
+    describe('when data is cached', () => {
+      it('does not call the get agreement lot suppliers endpoint but still returns the data', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+
+        const getAgreementLotSuppliersResult = await agreementsServiceAPI.getAgreementLotSuppliers(agreementId, lotId) as FetchResultOK<LotSupplier[]>;
+
+        expect(getAgreementLotSuppliersResult.status).to.eq(FetchResultStatus.OK);
+        expect(getAgreementLotSuppliersResult.data).to.eql(data);
+
+        assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234_suppliers');
+      });
     });
   });
 
   describe('getAgreementLotEventTypes', () => {
-    it('calls the get agreement lot event types endpoint with the correct url and headers', async () => {
-      const lotId = 'lotId-1234';
+    const lotId = 'lotId-1234';
+    const data = [{ type: 'myType' }];
 
-      mockPool.intercept({
-        method: 'GET',
-        path: `/agreements/${agreementId}/lots/${lotId}/event-types`,
-        headers: headers
-      }).reply(200, [{ type: 'myType' }]);
+    describe('when no data is cached', () => {
+      it('calls the get agreement lot event types endpoint with the correct url and headers', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock);
 
-      const getAgreementLotEventTypesResult = await agreementsServiceAPI.getAgreementLotEventTypes(agreementId, lotId) as FetchResultOK<AgreementLotEventType[]>;
+        mockPool.intercept({
+          method: 'GET',
+          path: `/agreements/${agreementId}/lots/${lotId}/event-types`,
+          headers: headers
+        }).reply(200, data);
 
-      expect(getAgreementLotEventTypesResult.status).to.eq(FetchResultStatus.OK);
-      expect(getAgreementLotEventTypesResult.data).to.eql([{ type: 'myType' }]);
+        const getAgreementLotEventTypesResult = await agreementsServiceAPI.getAgreementLotEventTypes(agreementId, lotId) as FetchResultOK<AgreementLotEventType[]>;
+
+        expect(getAgreementLotEventTypesResult.status).to.eq(FetchResultStatus.OK);
+        expect(getAgreementLotEventTypesResult.data).to.eql(data);
+
+        assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234_event_types', data, 3600);
+      });
+    });
+
+    describe('when data is cached', () => {
+      it('does not call the get agreement lot event types endpoint but still returns the data', async () => {
+        const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+
+        const getAgreementLotEventTypesResult = await agreementsServiceAPI.getAgreementLotEventTypes(agreementId, lotId) as FetchResultOK<AgreementLotEventType[]>;
+
+        expect(getAgreementLotEventTypesResult.status).to.eq(FetchResultStatus.OK);
+        expect(getAgreementLotEventTypesResult.data).to.eql(data);
+
+        assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234_event_types');
+      });
     });
   });
 });

--- a/src/test/utils/mocks/redis.ts
+++ b/src/test/utils/mocks/redis.ts
@@ -1,0 +1,73 @@
+import * as redis from 'redis';
+import Sinon from 'sinon';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import { createClient } from 'redis';
+
+type RedisClient = ReturnType<typeof createClient>
+
+chai.use(sinonChai);
+
+const mockRedisClient: RedisClient = {
+  on: (_eventName: string, _cb: () => void) => {
+    // Mocks the on function
+  },
+  connect: async () => {
+    // Mocks the connect function
+  },
+  disconnect: async () => {
+    // Mocks the disconnect function
+  },
+  get: async (_key: string): Promise<string> => {
+    // Mocks the get function and returns null
+
+    return null;
+  },
+  set: async (_key: string, _value: string, _options?: { [key: string]: string }) => {
+    // Mocks the set function
+  }
+} as any;
+
+const mockRedisClientWithData = (data: object): RedisClient => {
+  return {
+    ...mockRedisClient,
+    get: async (key: string): Promise<string> => {
+      // Mocks the get function and returns the data
+
+      return JSON.stringify(data);
+    }
+  } as RedisClient;;
+};
+
+const creatRedisMockSpy = (mock: Sinon.SinonSandbox, data?: object) => {
+  let mockRedisClientSpy: Sinon.SinonSpiedInstance<typeof mockRedisClient>;
+
+  if (data) {
+    const mockedRedisClient = mockRedisClientWithData(data);
+    mockRedisClientSpy = mock.spy(mockedRedisClient);
+    mock.stub(redis, 'createClient').returns(mockedRedisClient);
+  } else {
+    mockRedisClientSpy = mock.spy(mockRedisClient);
+    mock.stub(redis, 'createClient').returns(mockRedisClient);
+  }
+
+  return mockRedisClientSpy;
+};
+
+const assertRedisCalls = (mockRedisClientSpy: Sinon.SinonSpiedInstance<typeof mockRedisClient>, key: string, data: object, EX: number) => {
+  expect(mockRedisClientSpy.connect).to.have.been.called.callCount(2);
+  expect(mockRedisClientSpy.on).to.have.been.called.callCount(4);
+  expect(mockRedisClientSpy.get).to.have.been.called.calledOnceWith(key);
+  expect(mockRedisClientSpy.set).to.have.been.called.calledOnceWith(key, JSON.stringify(data), { EX: EX });
+  expect(mockRedisClientSpy.connect).to.have.been.called.callCount(2);
+};
+
+const assertRedisCallsWithCache = (mockRedisClientSpy: Sinon.SinonSpiedInstance<typeof mockRedisClient>, key: string) => {
+  expect(mockRedisClientSpy.connect).to.have.been.called.calledOnce;
+  expect(mockRedisClientSpy.on).to.have.been.called.callCount(2);
+  expect(mockRedisClientSpy.get).to.have.been.called.calledOnceWith(key);
+  expect(mockRedisClientSpy.set).not.to.have.been.called;
+  expect(mockRedisClientSpy.connect).to.have.been.called.calledOnce;
+};
+
+export { creatRedisMockSpy, assertRedisCalls, assertRedisCallsWithCache };


### PR DESCRIPTION
### JIRA link

[CAS-1586](https://crowncommercialservice.atlassian.net/browse/CAS-1586)

### Change description

I have added caching on the agreement service endpoints. I’ve set the following expiry times for the agreement service endpoints:

- GET /agreements/:agreement-id - 60 minutes
- GET /agreements/:agreement-id/lots - 60 minutes
- GET /agreements/:agreement-id/lots/:lot-id - 60 minutes
- GET /agreements:agreement-id/lots/:lot-id/event-types - 60 minutes
- GET /agreements:agreement-id/lots/:lot-id/suppliers - 15 minutes

This should help improve the performance of the application significantly as we call the agreement service API a lot.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


[CAS-1568]: https://crowncommercialservice.atlassian.net/browse/CAS-1568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CAS-1586]: https://crowncommercialservice.atlassian.net/browse/CAS-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ