### PR TITLE
CAS-1606 - Log all errors directly to Rollbar

### DIFF
--- a/src/main/common/logger/rollbarLogger.ts
+++ b/src/main/common/logger/rollbarLogger.ts
@@ -1,0 +1,14 @@
+import { initRollbar } from 'main/setup/rollbar';
+import { Logger } from '@hmcts/nodejs-logging';
+
+const defaultLogger = Logger.getLogger('app');
+
+const rollbarLogger = (error: any, logger: any = defaultLogger): void => {
+  const rollbar = initRollbar();
+
+  logger.error(`${error.stack || error}`);
+
+  if (rollbar) rollbar.error(error);
+};
+
+export { rollbarLogger };

--- a/src/main/common/logtracer/tracer.ts
+++ b/src/main/common/logtracer/tracer.ts
@@ -1,12 +1,8 @@
 import { LoggerInstance } from '../../common/util/fetch/logger/loggerInstance';
-import { LogMessageFormatter } from '../logtracer/logmessageformatter';
 import * as express from 'express';
 import { cookies } from '../cookies/cookies';
 import { ErrorView } from '../../common/shared/error/errorView';
-import { Logger } from '@hmcts/nodejs-logging';
-import { initRollbar } from 'main/setup/rollbar';
-import querystring from 'querystring';
-const logger = Logger.getLogger('logit helper');
+import { rollbarLogger } from '@common/logger/rollbarLogger';
 
 /**
  * @LogTracer for distribution tracing
@@ -45,162 +41,25 @@ export class LoggTracer {
     }
   };
 
-  static errorTracer = async (errorLog: LogMessageFormatter, res: express.Response): Promise<void> => {
-    //  const LogMessage = { AppName: 'Contract Award Service (CAS) frontend', type: 'error', errordetails: errorLog };
-    let body = null;
-    if (
-      errorLog?.exception?.config?.data != undefined &&
-      errorLog?.exception?.config?.data != null &&
-      errorLog?.exception?.config?.data != ''
-    ) {
-      try {
-        body = JSON.parse(errorLog?.exception?.config?.data);
-      } catch (error) {
-        const parsedObjectET = querystring.parse(errorLog?.exception?.config?.data);
-        const finalET = JSON.stringify(parsedObjectET);
-        body = JSON.parse(finalET);
-      }
-      // body = JSON.parse(errorLog?.exception?.config?.data)
-    }
-    // let req = express.request;
-
-    const LogMessage = {
-      environment: process.env.LOGIT_ENVIRONMENT,
-      logType: 'CAS_ERROR',
-      level: 'error',
-      statusCode: errorLog?.statusCode != undefined ? errorLog?.statusCode : null,
-      message: errorLog?.errorRoot,
-      baseUrl: errorLog?.exception?.config?.baseURL,
-      api: errorLog?.exception?.config?.url,
-      method: errorLog?.exception?.config?.method,
-      body: body,
-      startTime:
-        errorLog?.exception?.config?.metadata?.startTime != undefined
-          ? errorLog?.exception?.config?.metadata?.startTime
-          : null,
-      endTime:
-        errorLog?.exception?.config?.metadata?.endTime != undefined
-          ? errorLog?.exception?.config?.metadata?.endTime
-          : null,
-      duration: errorLog?.exception?.duration != undefined ? errorLog?.exception?.duration : null,
-      time: new Date(),
-      // "others":{
-      //   AppName: 'Contract Award Service (CAS) frontend', type: 'error', errordetails: errorLog
-      // }
-    };
-    if (process.env.LOGIT_API_KEY != '') {
-      await LoggerInstance.Instance.post('', LogMessage);
-    }
-
-    if (!isNaN(errorLog.statusCode) && errorLog.statusCode == 401) {
-      res.clearCookie(cookies.sessionID);
-      res.clearCookie(cookies.state);
-      res.redirect('/oauth/login');
-    } else res.render(ErrorView.internalServer);
-  };
-
-  /**
-   *
-   * @param errorLog
-   */
-  static errorTracerWithoutRedirect = async (errorLog: any): Promise<void> => {
-    // const LogMessage = {
-    //   AppName: 'Contract Award Service (CAS) frontend', type: 'error', errordetails: errorLog
-    //  };
-    let body = null;
-    if (
-      errorLog?.exception?.config?.data != undefined &&
-      errorLog?.exception?.config?.data != null &&
-      errorLog?.exception?.config?.data != ''
-    ) {
-      try {
-        body = JSON.parse(errorLog?.exception?.config?.data);
-      } catch (error) {
-        const parsedObjectETR = querystring.parse(errorLog?.exception?.config?.data);
-        const finalETR = JSON.stringify(parsedObjectETR);
-        body = JSON.parse(finalETR);
-      }
-      // body = JSON.parse(errorLog?.exception?.config?.data)
-    }
-
-    const LogMessage = {
-      environment: process.env.LOGIT_ENVIRONMENT,
-      logType: 'CAS_ERROR',
-      level: 'error',
-      statusCode: errorLog?.statusCode != undefined ? errorLog?.statusCode : null,
-      message: errorLog?.errorRoot,
-      baseUrl: errorLog?.exception?.config?.baseURL,
-      api: errorLog?.exception?.config?.url,
-      method: errorLog?.exception?.config?.method,
-      body: body,
-      startTime:
-        errorLog?.exception?.config?.metadata?.startTime != undefined
-          ? errorLog?.exception?.config?.metadata?.startTime
-          : null,
-      endTime:
-        errorLog?.exception?.config?.metadata?.endTime != undefined
-          ? errorLog?.exception?.config?.metadata?.endTime
-          : null,
-      duration: errorLog?.exception?.duration != undefined ? errorLog?.exception?.duration : null,
-      time: new Date(),
-      // "others":{
-      //   AppName: 'Contract Award Service (CAS) frontend', type: 'error', errordetails: errorLog
-      // }
-    };
-    if (process.env.LOGIT_API_KEY != '') {
-      await LoggerInstance.Instance.post('', LogMessage);
-    }
-  };
-
   static errorLogger = async (
     res: express.Response,
-    errorLog: any,
-    location: string,
-    sessionId: string,
-    userId: string,
-    error_reason: string,
+    error: any,
+    _location: string,
+    _sessionId: string,
+    _userId: string,
+    _error_reason: string,
     redirect?: boolean
   ): Promise<void> => {
-    delete errorLog?.config?.['headers'];
-    const Logmessage = {
-      Person_id: userId,
-      error_location: location,
-      sessionId: sessionId,
-      error_reason: error_reason,
-      exception: errorLog,
-    };
-
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception,
-      errorLog?.response?.status
-    );
-
-    logger.error('Exception logged in Logit: ' + error_reason);
-
-    const rollbar = initRollbar();
-
-    if (rollbar) {
-      const LogMessage = {
-        AppName: 'Contract Award Service (CAS) frontend',
-        type: 'error',
-        errordetails: Log,
-        browser: res.req.headers['sec-ch-ua'],
-        mobile: res.req.headers['sec-ch-ua-mobile'],
-        platform: res.req.headers['sec-ch-ua-platform'],
-        userAgent: res.req.headers['user-agent'],
-      };
-
-      rollbar.error(LogMessage, LogMessage.type + ' : ' + LogMessage.errordetails.errorRoot, res.req);
-    }
+    rollbarLogger(error);
 
     if (redirect) {
-      LoggTracer.errorTracer(Log, res);
-    } else {
-      LoggTracer.errorTracerWithoutRedirect(Log);
+      if (!isNaN(error?.response?.status) && error?.response?.status === 401) {
+        res.clearCookie(cookies.sessionID);
+        res.clearCookie(cookies.state);
+        res.redirect('/oauth/login');
+      } else {
+        res.render(ErrorView.internalServer);
+      };
     }
   };
 }

--- a/src/main/features/da/controller/da-questions-yourassesstment.ts
+++ b/src/main/features/da/controller/da-questions-yourassesstment.ts
@@ -204,22 +204,15 @@ export const DA_Assesstment_GET_QUESTIONS = async (req: express.Request, res: ex
 
     res.render('daw-question-assessment', data);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'DA Dynamic framework throws error - Tenders Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -658,7 +651,6 @@ export const DA_Assesstment_POST_QUESTION = async (req: express.Request, res: ex
                   'DA Question Assessments - Tenders Service Api cannot be connected',
                   true
                 );
-                // LoggTracer.errorTracer(error, res);
               }
             }
           }
@@ -690,7 +682,6 @@ export const DA_Assesstment_POST_QUESTION = async (req: express.Request, res: ex
       res.redirect('/error');
     }
   } catch (err) {
-    // LoggTracer.errorTracer(err, res);
     LoggTracer.errorLogger(
       res,
       err,

--- a/src/main/features/da/controller/da-questions.ts
+++ b/src/main/features/da/controller/da-questions.ts
@@ -301,22 +301,15 @@ export const DA_GET_QUESTIONS = async (req: express.Request, res: express.Respon
     LoggTracer.infoLogger(null, logConstant.questionPage, req);
     res.render('daw-question', data);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'DA Dynamic framework throws error - Tenders Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -877,7 +870,6 @@ export const DA_POST_QUESTIONS = async (req: express.Request, res: express.Respo
       'DA Question - Tenders Service Api cannot be connected',
       true
     );
-    // LoggTracer.errorTracer(err, res);
   }
 };
 

--- a/src/main/features/da/controller/da-responsedate.ts
+++ b/src/main/features/da/controller/da-responsedate.ts
@@ -617,22 +617,15 @@ export const DA_POST_ADD_RESPONSE_DATE = async (req: express.Request, res: expre
         await TenderApi.Instance(SESSION_ID).put(answerBaseURL, answerBody);
         res.redirect('/da/response-date');
       } catch (error) {
-        delete error?.config?.['headers'];
-        const Logmessage = {
-          Person_id: TokenDecoder.decoder(SESSION_ID),
-          error_location: `${req.headers.host}${req.originalUrl}`,
-          sessionId: 'null',
-          error_reason: 'DA Timeline - Dyanamic framework throws error - Tender Api is causing problem',
-          exception: error,
-        };
-        const Log = new LogMessageFormatter(
-          Logmessage.Person_id,
-          Logmessage.error_location,
-          Logmessage.sessionId,
-          Logmessage.error_reason,
-          Logmessage.exception
+        LoggTracer.errorLogger(
+          res,
+          error,
+          null,
+          null,
+          null,
+          null,
+          false
         );
-        LoggTracer.errorTracer(Log, res);
       }
     } else {
       const selectedErrorCause = selected_question_id; //Question 2

--- a/src/main/features/da/controller/da-review.ts
+++ b/src/main/features/da/controller/da-review.ts
@@ -1106,22 +1106,15 @@ const DA_REVIEW_RENDER_TEST = async (
     LoggTracer.infoLogger(null, logConstant.ReviewLog, req);
     res.render('daw-review', appendData);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'DA Review - Dyanamic framework throws error - Tender Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -1402,21 +1395,14 @@ const DA_REVIEW_RENDER = async (req: express.Request, res: express.Response, vie
     LoggTracer.infoLogger(null, logConstant.ReviewLog, req);
     res.render('daw-review', appendData);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'DA Review - Dyanamic framework throws error - Tender Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };

--- a/src/main/features/da/controller/da-upload.ts
+++ b/src/main/features/da/controller/da-upload.ts
@@ -189,22 +189,15 @@ export const DA_POST_UPLOAD_DOC: express.Handler = async (req: express.Request, 
               //res.redirect(`/${selRoute}/upload-doc`);
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: `File uploading Causes Problem in ${selRoute}  - Tenders Api throws error`,
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/da/controller/da-uploadAdditional.ts
+++ b/src/main/features/da/controller/da-uploadAdditional.ts
@@ -188,23 +188,15 @@ export const DA_POST_UPLOAD_ADDITIONAL: express.Handler = async (req: express.Re
               //res.redirect(`/${selRoute}/upload-additional`);
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: `File uploading Causes Problem in ${selRoute}  - Tenders Api throws error`,
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception,
-              Logmessage.sessionId
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/da/controller/da-uploadAttachment.ts
+++ b/src/main/features/da/controller/da-uploadAttachment.ts
@@ -190,22 +190,15 @@ export const DA_POST_UPLOAD_ATTACHMENT: express.Handler = async (req: express.Re
               res.redirect('/da/upload-attachment');
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: `File uploading Causes Problem in ${selRoute}  - Tenders Api throws error`,
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/da/helpers/upload.ts
+++ b/src/main/features/da/helpers/upload.ts
@@ -45,22 +45,15 @@ export const FILEUPLOADHELPER: express.Handler = async (
       });
       res.send(fileData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `File uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -149,22 +142,15 @@ export const FILEUPLOADHELPER: express.Handler = async (
       // res.render(`${selectedRoute.toLowerCase()}-uploadDocument`, windowAppendData);
       res.render('daw-uploadDocument', windowAppendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `File uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/da/helpers/uploadAdditional.ts
+++ b/src/main/features/da/helpers/uploadAdditional.ts
@@ -56,22 +56,15 @@ export const ADDITIONALUPLOADHELPER: express.Handler = async (
       }
       res.send(fileData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Additional uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -187,22 +180,15 @@ export const ADDITIONALUPLOADHELPER: express.Handler = async (
       LoggTracer.infoLogger(null, logConstant.eoiUploadDocumentPageLog, req);
       res.render('daw-uploadAdditional', windowAppendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Additional uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/da/helpers/uploadAttachment.ts
+++ b/src/main/features/da/helpers/uploadAttachment.ts
@@ -61,22 +61,15 @@ export const ATTACHMENTUPLOADHELPER: express.Handler = async (
       }
       res.send(fileData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Attachment uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -172,22 +165,15 @@ export const ATTACHMENTUPLOADHELPER: express.Handler = async (
       LoggTracer.infoLogger(null, logConstant.eoiUploadDocumentPageLog, req);
       res.render('daw-uploadAttachment', windowAppendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Attachment uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/eoi/controller/questions.ts
+++ b/src/main/features/eoi/controller/questions.ts
@@ -185,22 +185,15 @@ export const GET_QUESTIONS = async (req: express.Request, res: express.Response)
 
     res.render('questionsEoi', data);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'EOI Dynamic framework throws error - Tenders Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -576,8 +569,16 @@ export const POST_QUESTION = async (req: express.Request, res: express.Response)
     } else {
       res.redirect('/error');
     }
-  } catch (err) {
-    LoggTracer.errorTracer(err, res);
+  } catch (error) {
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
+    );
   }
 };
 

--- a/src/main/features/eoi/controller/responseDate.ts
+++ b/src/main/features/eoi/controller/responseDate.ts
@@ -377,22 +377,15 @@ export const POST_ADD_RESPONSE_DATE = async (req: express.Request, res: express.
 
         res.redirect('/eoi/response-date');
       } catch (error) {
-        delete error?.config?.['headers'];
-        const Logmessage = {
-          Person_id: TokenDecoder.decoder(SESSION_ID),
-          error_location: `${req.headers.host}${req.originalUrl}`,
-          sessionId: 'null',
-          error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-          exception: error,
-        };
-        const Log = new LogMessageFormatter(
-          Logmessage.Person_id,
-          Logmessage.error_location,
-          Logmessage.sessionId,
-          Logmessage.error_reason,
-          Logmessage.exception
+        LoggTracer.errorLogger(
+          res,
+          error,
+          null,
+          null,
+          null,
+          null,
+          false
         );
-        LoggTracer.errorTracer(Log, res);
       }
     } else {
       const selectedErrorCause = selected_question_id; //Question 2

--- a/src/main/features/eoi/controller/review.ts
+++ b/src/main/features/eoi/controller/review.ts
@@ -399,22 +399,15 @@ const EOI_REVIEW_RENDER = async (
 
       res.render('reviewEoi', appendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/eoi/controller/upload.ts
+++ b/src/main/features/eoi/controller/upload.ts
@@ -179,22 +179,15 @@ export const POST_UPLOAD_DOC: express.Handler = async (req: express.Request, res
               res.redirect('/eoi/upload-doc');
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: 'File uploading Causes Problem in EOI  - Tenders Api throws error',
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/eoi/helpers/upload.ts
+++ b/src/main/features/eoi/helpers/upload.ts
@@ -45,22 +45,15 @@ export const FILEUPLOADHELPER: express.Handler = async (
       });
       res.send(fileData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: 'EOI - File uploading Causes Problem in EOI  - Tenders Api throws error',
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -110,22 +103,15 @@ export const FILEUPLOADHELPER: express.Handler = async (
 
       res.render('uploadDocumentEoi', windowAppendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: 'EOI - File uploading Causes Problem in EOI  - Tenders Api throws error',
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/requirements/controller/ca-upload.ts
+++ b/src/main/features/requirements/controller/ca-upload.ts
@@ -123,22 +123,15 @@ export const CA_POST_UPLOAD_DOC: express.Handler = async (req: express.Request, 
           });
           res.redirect(`/${selRoute}/upload-doc`);
         } catch (error) {
-          delete error?.config?.['headers'];
-          const Logmessage = {
-            Person_id: TokenDecoder.decoder(SESSION_ID),
-            error_location: `${req.headers.host}${req.originalUrl}`,
-            sessionId: 'null',
-            error_reason: `File uploading Causes Problem in ${selRoute}  - Tenders Api throws error`,
-            exception: error,
-          };
-          const Log = new LogMessageFormatter(
-            Logmessage.Person_id,
-            Logmessage.error_location,
-            Logmessage.sessionId,
-            Logmessage.error_reason,
-            Logmessage.exception
+          LoggTracer.errorLogger(
+            res,
+            error,
+            null,
+            null,
+            null,
+            null,
+            false
           );
-          LoggTracer.errorTracer(Log, res);
         }
       } else {
         FileFilterArray.push({

--- a/src/main/features/requirements/controller/rfp-quality_group.ts
+++ b/src/main/features/requirements/controller/rfp-quality_group.ts
@@ -67,6 +67,14 @@ export const RFP_POST_QUALITY_GROUP = async (req: express.Request, res: express.
     }
     res.redirect('/rfp/ratio-quality-group');
   } catch (error) {
-    LoggTracer.errorTracer(error, res);
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
+    );
   }
 };

--- a/src/main/features/requirements/controller/rfp-questions-yourassesstment.ts
+++ b/src/main/features/requirements/controller/rfp-questions-yourassesstment.ts
@@ -342,22 +342,15 @@ export const RFP_Assesstment_GET_QUESTIONS = async (req: express.Request, res: e
     LoggTracer.infoLogger(null, data.rfpTitle, req);
     res.render('rfp-question-assessment', data);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'FC Dynamic framework throws error - Tenders Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -876,7 +869,15 @@ export const RFP_Assesstment_POST_QUESTION = async (req: express.Request, res: e
                   }
                 }
               } catch (error) {
-                LoggTracer.errorTracer(error, res);
+                LoggTracer.errorLogger(
+                  res,
+                  error,
+                  null,
+                  null,
+                  null,
+                  null,
+                  false
+                );
               }
             }
           }
@@ -907,24 +908,16 @@ export const RFP_Assesstment_POST_QUESTION = async (req: express.Request, res: e
     } else {
       res.redirect('/error');
     }
-  } catch (err) {
-    delete err?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'FC Dynamic framework throws error - Tenders Api is causing problem',
-      exception: err,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+  } catch (error) {
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-
-    LoggTracer.errorTracer(Log, res);
   }
 };
 

--- a/src/main/features/requirements/controller/rfp-questions.ts
+++ b/src/main/features/requirements/controller/rfp-questions.ts
@@ -507,22 +507,15 @@ export const RFP_GET_QUESTIONS = async (req: express.Request, res: express.Respo
     LoggTracer.infoLogger(null, data.rfpTitle, req);
     res.render('rfp-question', data);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'FC Dynamic framework throws error - Tenders Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -1232,25 +1225,16 @@ export const RFP_POST_QUESTION = async (req: express.Request, res: express.Respo
     } else {
       res.redirect('/error');
     }
-  } catch (err) {
-    delete err?.config?.['headers'];
-    const { SESSION_ID } = req.cookies;
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'FC Dynamic framework throws error - Tenders Api is causing problem',
-      exception: err,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+  } catch (error) {
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-
-    LoggTracer.errorTracer(Log, res);
   }
 };
 

--- a/src/main/features/requirements/controller/rfp-responsedate.ts
+++ b/src/main/features/requirements/controller/rfp-responsedate.ts
@@ -849,24 +849,6 @@ export const RFP_POST_ADD_RESPONSE_DATE = async (req: express.Request, res: expr
         const answerBaseURL = `/tenders/projects/${proc_id}/events/${event_id}/criteria/${id}/groups/${group_id}/questions/${question_id}`;
         await TenderApi.Instance(SESSION_ID).put(answerBaseURL, answerBody);
         res.redirect('/rfp/response-date');
-        // } catch (error) {
-        //   delete error?.config?.['headers'];
-        //   const Logmessage = {
-        //     Person_id: TokenDecoder.decoder(SESSION_ID),
-        //     error_location: `${req.headers.host}${req.originalUrl}`,
-        //     sessionId: 'null',
-        //     error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-        //     exception: error,
-        //   };
-        //   const Log = new LogMessageFormatter(
-        //     Logmessage.Person_id,
-        //     Logmessage.error_location,
-        //     Logmessage.sessionId,
-        //     Logmessage.error_reason,
-        //     Logmessage.exception
-        //   );
-        //   LoggTracer.errorTracer(Log, res);
-        // }
       } else {
         const selectedErrorCause = selected_question_id; //Question 2
         let selector = '';
@@ -952,22 +934,15 @@ export const RFP_POST_ADD_RESPONSE_DATE = async (req: express.Request, res: expr
         await RESPONSEDATEHELPER(req, res, true, errorItem);
       }
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/requirements/controller/rfp-review.ts
+++ b/src/main/features/requirements/controller/rfp-review.ts
@@ -654,22 +654,15 @@ const RFP_REVIEW_RENDER_STAGE = async (
     LoggTracer.infoLogger(null, logConstant.reviewAndPublishStageTwo, req);
     res.render('rfp-review-stage', appendData);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 const RFP_REVIEW_RENDER_TEST = async (
@@ -2599,22 +2592,15 @@ const RFP_REVIEW_RENDER_TEST = async (
       res.render('rfp-review', appendData);
     }
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -2908,22 +2894,15 @@ const RFP_REVIEW_RENDER = async (
 
     res.render('rfp-review', appendData);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -4017,22 +3996,15 @@ const RFP_REVIEW_RENDER_TEST_MCF = async (
     LoggTracer.infoLogger(null, logConstant.reviewAndPublish, req);
     res.render('rfp-review', appendData);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -4866,21 +4838,14 @@ const RFP_REVIEW_RENDER_GCLOUD = async (
     LoggTracer.infoLogger(null, logConstant.reviewAndPublish, req);
     res.render('rfp-gcloudreview', appendData);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'Dyanamic framework throws error - Tender Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };

--- a/src/main/features/requirements/controller/rfp-scoringCriteria.ts
+++ b/src/main/features/requirements/controller/rfp-scoringCriteria.ts
@@ -491,7 +491,15 @@ export const RFP_POST_SCORING_CRITERIA = async (req: express.Request, res: expre
                   break;
                 }
               } catch (error) {
-                LoggTracer.errorTracer(error, res);
+                LoggTracer.errorLogger(
+                  res,
+                  error,
+                  null,
+                  null,
+                  null,
+                  null,
+                  false
+                );
               }
             }
           }
@@ -955,7 +963,15 @@ export const RFP_Assesstment_POST_QUESTION = async (req: express.Request, res: e
                   res.redirect('/rfp/task-list');
                 }
               } catch (error) {
-                LoggTracer.errorTracer(error, res);
+                LoggTracer.errorLogger(
+                  res,
+                  error,
+                  null,
+                  null,
+                  null,
+                  null,
+                  false
+                );
               }
             }
           }
@@ -986,8 +1002,16 @@ export const RFP_Assesstment_POST_QUESTION = async (req: express.Request, res: e
     } else {
       res.redirect('/error');
     }
-  } catch (err) {
-    LoggTracer.errorTracer(err, res);
+  } catch (error) {
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
+    );
   }
 };
 

--- a/src/main/features/requirements/controller/rfp-upload.ts
+++ b/src/main/features/requirements/controller/rfp-upload.ts
@@ -195,22 +195,15 @@ export const RFP_POST_UPLOAD_DOC: express.Handler = async (req: express.Request,
               res.redirect(`/${selRoute}/upload-doc`);
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: `File uploading Causes Problem in ${selRoute}  - Tenders Api throws error`,
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/requirements/controller/rfp-uploadAdditional.ts
+++ b/src/main/features/requirements/controller/rfp-uploadAdditional.ts
@@ -191,23 +191,15 @@ export const RFP_POST_UPLOAD_ADDITIONAL: express.Handler = async (req: express.R
               res.redirect(`/${selRoute}/upload-additional`);
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: `File uploading Causes Problem in ${selRoute}  - Tenders Api throws error`,
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception,
-              Logmessage.sessionId
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/requirements/controller/rfp-uploadAdditionalDoc.ts
+++ b/src/main/features/requirements/controller/rfp-uploadAdditionalDoc.ts
@@ -193,23 +193,15 @@ export const RFP_POST_UPLOAD_ADDITIONAL_DOC: express.Handler = async (req: expre
               res.redirect(`/${selRoute}/upload-additional-doc`);
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: `File uploading Causes Problem in ${selRoute}  - Tenders Api throws error`,
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception,
-              Logmessage.sessionId
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/requirements/controller/rfp-uploadAttachment.ts
+++ b/src/main/features/requirements/controller/rfp-uploadAttachment.ts
@@ -186,22 +186,15 @@ export const RFP_POST_UPLOAD_ATTACHMENT: express.Handler = async (req: express.R
               res.redirect(`/${selRoute}/upload-attachment`);
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: `File uploading Causes Problem in ${selRoute}  - Tenders Api throws error`,
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/requirements/helpers/upload.ts
+++ b/src/main/features/requirements/helpers/upload.ts
@@ -52,22 +52,15 @@ export const FILEUPLOADHELPER: express.Handler = async (
       });
       res.send(fileData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `File uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -202,22 +195,15 @@ export const FILEUPLOADHELPER: express.Handler = async (
 
       res.render(`${selectedRoute.toLowerCase()}-uploadDocument`, windowAppendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `File uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/requirements/helpers/uploadAdditional.ts
+++ b/src/main/features/requirements/helpers/uploadAdditional.ts
@@ -57,23 +57,15 @@ export const ADDITIONALUPLOADHELPER: express.Handler = async (
       }
       res.send(fileData);
     } catch (error) {
-      console.log(error);
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Additional uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -249,23 +241,15 @@ export const ADDITIONALUPLOADHELPER: express.Handler = async (
 
       res.render(`${selectedRoute.toLowerCase()}-uploadAdditional`, windowAppendData);
     } catch (error) {
-      console.log(error);
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Additional uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/requirements/helpers/uploadAdditionalDoc.ts
+++ b/src/main/features/requirements/helpers/uploadAdditionalDoc.ts
@@ -57,22 +57,15 @@ export const ADDITIONALUPLOADHELPER_DOC: express.Handler = async (
       }
       res.send(fileData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Additional uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -236,22 +229,15 @@ export const ADDITIONALUPLOADHELPER_DOC: express.Handler = async (
 
       res.render(`${selectedRoute.toLowerCase()}-uploadAdditionalDoc`, windowAppendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Additional uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/requirements/helpers/uploadAttachment.ts
+++ b/src/main/features/requirements/helpers/uploadAttachment.ts
@@ -62,22 +62,15 @@ export const ATTACHMENTUPLOADHELPER: express.Handler = async (
 
       res.send(fileData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Attachment uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -219,22 +212,15 @@ export const ATTACHMENTUPLOADHELPER: express.Handler = async (
 
       res.render(`${selectedRoute.toLowerCase()}-uploadAttachment`, windowAppendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: `Attachment uploading Causes Problem in ${selectedRoute}  - Tenders Api throws error`,
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/rfi/controller/questions.ts
+++ b/src/main/features/rfi/controller/questions.ts
@@ -130,22 +130,15 @@ export const GET_QUESTIONS = async (req: express.Request, res: express.Response)
 
     res.render('questions', data);
   } catch (error) {
-    delete error?.config?.['headers'];
-    const Logmessage = {
-      Person_id: TokenDecoder.decoder(SESSION_ID),
-      error_location: `${req.headers.host}${req.originalUrl}`,
-      sessionId: 'null',
-      error_reason: 'RFI Dynamic framework throws error - Tenders Api is causing problem',
-      exception: error,
-    };
-    const Log = new LogMessageFormatter(
-      Logmessage.Person_id,
-      Logmessage.error_location,
-      Logmessage.sessionId,
-      Logmessage.error_reason,
-      Logmessage.exception
+    LoggTracer.errorLogger(
+      res,
+      error,
+      null,
+      null,
+      null,
+      null,
+      false
     );
-    LoggTracer.errorTracer(Log, res);
   }
 };
 
@@ -268,22 +261,15 @@ export const POST_QUESTION = async (req: express.Request, res: express.Response)
                 return;
               }
             } catch (error) {
-              delete error?.config?.['headers'];
-              const Logmessage = {
-                Person_id: TokenDecoder.decoder(SESSION_ID),
-                error_location: `${req.headers.host}${req.originalUrl}`,
-                sessionId: 'null',
-                error_reason: 'RFI Question - Dyanamic framework throws error - Tender Api is causing problem',
-                exception: error,
-              };
-              const Log = new LogMessageFormatter(
-                Logmessage.Person_id,
-                Logmessage.error_location,
-                Logmessage.sessionId,
-                Logmessage.error_reason,
-                Logmessage.exception
+              LoggTracer.errorLogger(
+                res,
+                error,
+                null,
+                null,
+                null,
+                null,
+                false
               );
-              LoggTracer.errorTracer(Log, res);
             }
           } else if (questionType === 'KeyValuePairtrue') {
             let { term, value } = req.body;
@@ -329,22 +315,15 @@ export const POST_QUESTION = async (req: express.Request, res: express.Response)
                 return;
               }
             } catch (error) {
-              delete error?.config?.['headers'];
-              const Logmessage = {
-                Person_id: TokenDecoder.decoder(SESSION_ID),
-                error_location: `${req.headers.host}${req.originalUrl}`,
-                sessionId: 'null',
-                error_reason: 'RFI Question - Dyanamic framework throws error - Tender Api is causing problem',
-                exception: error,
-              };
-              const Log = new LogMessageFormatter(
-                Logmessage.Person_id,
-                Logmessage.error_location,
-                Logmessage.sessionId,
-                Logmessage.error_reason,
-                Logmessage.exception
+              LoggTracer.errorLogger(
+                res,
+                error,
+                null,
+                null,
+                null,
+                null,
+                false
               );
-              LoggTracer.errorTracer(Log, res);
             }
           } else {
             const question_array_check: boolean = Array.isArray(question_id);
@@ -388,22 +367,15 @@ export const POST_QUESTION = async (req: express.Request, res: express.Response)
                     req
                   );
                 } catch (error) {
-                  delete error?.config?.['headers'];
-                  const Logmessage = {
-                    Person_id: TokenDecoder.decoder(SESSION_ID),
-                    error_location: `${req.headers.host}${req.originalUrl}`,
-                    sessionId: 'null',
-                    error_reason: 'RFI Dynamic framework throws error - Tender Api is causing problem',
-                    exception: error,
-                  };
-                  const Log = new LogMessageFormatter(
-                    Logmessage.Person_id,
-                    Logmessage.error_location,
-                    Logmessage.sessionId,
-                    Logmessage.error_reason,
-                    Logmessage.exception
+                  LoggTracer.errorLogger(
+                    res,
+                    error,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false
                   );
-                  LoggTracer.errorTracer(Log, res);
                 }
               }
             } else {
@@ -532,22 +504,15 @@ export const POST_QUESTION = async (req: express.Request, res: express.Response)
                   );
                 }
               } catch (error) {
-                delete error?.config?.['headers'];
-                const Logmessage = {
-                  Person_id: TokenDecoder.decoder(SESSION_ID),
-                  error_location: `${req.headers.host}${req.originalUrl}`,
-                  sessionId: 'null',
-                  error_reason: 'RFI Question - Dyanamic framework throws error - Tender Api is causing problem',
-                  exception: error,
-                };
-                const Log = new LogMessageFormatter(
-                  Logmessage.Person_id,
-                  Logmessage.error_location,
-                  Logmessage.sessionId,
-                  Logmessage.error_reason,
-                  Logmessage.exception
+                LoggTracer.errorLogger(
+                  res,
+                  error,
+                  null,
+                  null,
+                  null,
+                  null,
+                  false
                 );
-                LoggTracer.errorTracer(Log, res);
               }
             }
           }

--- a/src/main/features/rfi/controller/responsedate.ts
+++ b/src/main/features/rfi/controller/responsedate.ts
@@ -401,22 +401,15 @@ export const POST_ADD_RESPONSE_DATE = async (req: express.Request, res: express.
 
         res.redirect('/rfi/response-date');
       } catch (error) {
-        delete error?.config?.['headers'];
-        const Logmessage = {
-          Person_id: TokenDecoder.decoder(SESSION_ID),
-          error_location: `${req.headers.host}${req.originalUrl}`,
-          sessionId: 'null',
-          error_reason: 'RFI Timeline - Dyanamic framework throws error - Tender Api is causing problem',
-          exception: error,
-        };
-        const Log = new LogMessageFormatter(
-          Logmessage.Person_id,
-          Logmessage.error_location,
-          Logmessage.sessionId,
-          Logmessage.error_reason,
-          Logmessage.exception
+        LoggTracer.errorLogger(
+          res,
+          error,
+          null,
+          null,
+          null,
+          null,
+          false
         );
-        LoggTracer.errorTracer(Log, res);
       }
     } else {
       const selectedErrorCause = selected_question_id; //Question 2

--- a/src/main/features/rfi/controller/upload.ts
+++ b/src/main/features/rfi/controller/upload.ts
@@ -173,22 +173,15 @@ export const POST_UPLOAD_DOC: express.Handler = async (req: express.Request, res
               res.redirect('/rfi/upload-doc');
             }
           } catch (error) {
-            delete error?.config?.['headers'];
-            const Logmessage = {
-              Person_id: TokenDecoder.decoder(SESSION_ID),
-              error_location: `${req.headers.host}${req.originalUrl}`,
-              sessionId: 'null',
-              error_reason: 'File uploading Causes Problem in RFI  - Tenders Api throws error',
-              exception: error,
-            };
-            const Log = new LogMessageFormatter(
-              Logmessage.Person_id,
-              Logmessage.error_location,
-              Logmessage.sessionId,
-              Logmessage.error_reason,
-              Logmessage.exception
+            LoggTracer.errorLogger(
+              res,
+              error,
+              null,
+              null,
+              null,
+              null,
+              false
             );
-            LoggTracer.errorTracer(Log, res);
           }
         } else {
           FileFilterArray.push({

--- a/src/main/features/rfi/helpers/review.ts
+++ b/src/main/features/rfi/helpers/review.ts
@@ -324,22 +324,15 @@ export const RFI_REVIEW_HELPER = async (
 
       res.render('review', appendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: 'RFI Review - Dyanamic framework throws error - Tender Api is causing problem',
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };

--- a/src/main/features/rfi/helpers/upload.ts
+++ b/src/main/features/rfi/helpers/upload.ts
@@ -46,22 +46,15 @@ export const FILEUPLOADHELPER: express.Handler = async (
       });
       res.send(fileData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: 'File uploading Causes Problem in RFI  - Tenders Api throws error',
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   } else {
     try {
@@ -115,22 +108,15 @@ export const FILEUPLOADHELPER: express.Handler = async (
 
       res.render(type === 'rfi' ? 'uploadDocument' : 'uploadDocumentEoi', windowAppendData);
     } catch (error) {
-      delete error?.config?.['headers'];
-      const Logmessage = {
-        Person_id: TokenDecoder.decoder(SESSION_ID),
-        error_location: `${req.headers.host}${req.originalUrl}`,
-        sessionId: 'null',
-        error_reason: 'File uploading Causes Problem in RFI  - Tenders Api throws error',
-        exception: error,
-      };
-      const Log = new LogMessageFormatter(
-        Logmessage.Person_id,
-        Logmessage.error_location,
-        Logmessage.sessionId,
-        Logmessage.error_reason,
-        Logmessage.exception
+      LoggTracer.errorLogger(
+        res,
+        error,
+        null,
+        null,
+        null,
+        null,
+        false
       );
-      LoggTracer.errorTracer(Log, res);
     }
   }
 };


### PR DESCRIPTION
### JIRA link

[CAS-1606](https://crowncommercialservice.atlassian.net/browse/CAS-1606)

### Change description

I have gutted the `LoggTracer.errorLogger` so that it only sends the exceptions straight to rollbar before it redirects (or doesn’t redirect) to the 500 page. To help with this I’ve created a Rollbar logger function that will automatically do the logging for us.

I’ve also replaced all the calls of `LoggTracer.errorTracer` to call the `LoggTracer.errorLogger` passing only the exception and the response object.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


[CAS-1606]: https://crowncommercialservice.atlassian.net/browse/CAS-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ