### PR TITLE
Refactor URL format helpers

### DIFF
--- a/src/main/services/agreementsService/api.ts
+++ b/src/main/services/agreementsService/api.ts
@@ -20,9 +20,7 @@ const getAgreement = async (agreementId: string): Promise<FetchResult<AgreementD
     {
       baseURL: baseURL,
       path: EndPoints.AGREEMENT,
-      params: [
-        [':agreement-id', agreementId]
-      ]
+      params: { agreementId }
     },
     headers,
     {
@@ -38,9 +36,7 @@ const getAgreementLots = async (agreementId: string): Promise<FetchResult<LotDet
     {
       baseURL: baseURL,
       path: EndPoints.AGREEMENT_LOTS,
-      params: [
-        [':agreement-id', agreementId]
-      ]
+      params: { agreementId }
     },
     headers,
     {
@@ -56,10 +52,7 @@ const getAgreementLot = async (agreementId: string, lotId: string): Promise<Fetc
     {
       baseURL: baseURL,
       path: EndPoints.AGREEMENT_LOT,
-      params: [
-        [':agreement-id', agreementId],
-        [':lot-id', lotId]
-      ]
+      params: { agreementId, lotId }
     },
     headers,
     {
@@ -75,10 +68,7 @@ const getAgreementLotSuppliers = async (agreementId: string, lotId: string): Pro
     {
       baseURL: baseURL,
       path: EndPoints.AGREEMENT_LOT_SUPPLIERS,
-      params: [
-        [':agreement-id', agreementId],
-        [':lot-id', lotId]
-      ]
+      params: { agreementId, lotId }
     },
     headers,
     {
@@ -94,10 +84,7 @@ const getAgreementLotEventTypes = async (agreementId: string, lotId: string): Pr
     {
       baseURL: baseURL,
       path: EndPoints.AGREEMENT_LOT_EVENT_TYPES,
-      params: [
-        [':agreement-id', agreementId],
-        [':lot-id', lotId]
-      ]
+      params: { agreementId, lotId }
     },
     headers,
     {

--- a/src/main/services/contentService/api.ts
+++ b/src/main/services/contentService/api.ts
@@ -12,9 +12,7 @@ const getMenu = async (menuId: string): Promise<FetchResult<ContentServiceMenu>>
     {
       baseURL: baseURL,
       path: EndPoints.MENU,
-      params: [
-        [':menu-id', menuId]
-      ]
+      params: { menuId }
     },
     {
       'Content-Type': 'application/json',

--- a/src/main/services/gCloud/service/api.ts
+++ b/src/main/services/gCloud/service/api.ts
@@ -16,9 +16,7 @@ const getService = async (serviceId: string): Promise<FetchResult<GCloudService>
     {
       baseURL: baseURL,
       path: EndPoints.SERVICE,
-      params: [
-        [':service-id', serviceId]
-      ]
+      params: { serviceId }
     },
     headers
   );
@@ -30,9 +28,7 @@ const getSupplier = async (supplierId: string): Promise<FetchResult<GCloudSuppli
     {
       baseURL: baseURL,
       path: EndPoints.SUPPLIER,
-      params: [
-        [':supplier-id', supplierId]
-      ]
+      params: { supplierId }
     },
     headers
   );
@@ -44,9 +40,7 @@ const getSupplierFramework = async (supplierId: string): Promise<FetchResult<GCl
     {
       baseURL: baseURL,
       path: EndPoints.SUPPLIER_FRAMEWORK,
-      params: [
-        [':supplier-id', supplierId]
-      ]
+      params: { supplierId }
     },
     headers
   );

--- a/src/main/services/helpers/url.ts
+++ b/src/main/services/helpers/url.ts
@@ -1,16 +1,11 @@
-import { FormatURLParams } from '../types/helpers/url';
+import { FormatURLParams, FormatRelativeURLParams } from '../types/helpers/url';
 
-/**
- * Formats a URL from the given options
- * @param options 
- * @returns 
- */
-const formatURL = (options: FormatURLParams): string => {
+const baseFormatURL = (options: FormatURLParams): URL => {
   const { baseURL, params, queryParams } = options;
   let { path } = options;
 
   if (options.params) {
-    params.forEach(([param, value]) => path = path.replace(param, value));
+    Object.entries(params).forEach(([param, value]) => path = path.replace(`:${param}`, value));
   }
 
   const url = new URL(path, baseURL);
@@ -19,7 +14,27 @@ const formatURL = (options: FormatURLParams): string => {
     url.search = (new URLSearchParams(queryParams)).toString();
   }
 
-  return url.toString();
+  return url;
 };
 
-export { formatURL };
+/**
+ * Formats a URL from the given options
+ * @param options 
+ * @returns 
+ */
+const formatURL = (options: FormatURLParams): string => {
+  return baseFormatURL(options).toString();
+};
+
+/**
+ * Formats a relative URL from the given options
+ * @param options 
+ * @returns 
+ */
+const formatRelativeURL = (options: FormatRelativeURLParams): string => {
+  const url = baseFormatURL({ baseURL: 'https://www.crowncommercial.gov.uk', ...options });
+
+  return `${url.pathname}${url.search}`;
+};
+
+export { formatURL, formatRelativeURL };

--- a/src/main/services/publicProcurementGateway/organisation/api.ts
+++ b/src/main/services/publicProcurementGateway/organisation/api.ts
@@ -9,21 +9,13 @@ const headers = {
   'x-api-key': process.env.CONCLAVE_WRAPPER_API_KEY
 };
 
-const endPoints: EndPoints = {
-  organisation: '/organisation-profiles/:organisation-id',
-  organisationUsers: '/organisation-profiles/:organisation-id/users',
-  userProfiles: '/user-profiles'
-};
-
 // GET /organisation-profiles/:organisation-id
 const getOrganisation = async (organisationId: string, queryParams?: { [key: string]: string }): Promise<FetchResult<Organisation>> => {
   return genericFecthGet<Organisation>(
     {
       baseURL: baseURL,
-      path: endPoints.organisation,
-      params: [
-        [':organisation-id', organisationId]
-      ],
+      path: EndPoints.ORGANISATION,
+      params: { organisationId },
       queryParams: queryParams
     },
     headers
@@ -35,10 +27,8 @@ const getOrganisationUsers = async (organisationId: string, queryParams?: { [key
   return genericFecthGet<OrganisationUsers>(
     {
       baseURL: baseURL,
-      path: endPoints.organisationUsers,
-      params: [
-        [':organisation-id', organisationId]
-      ],
+      path: EndPoints.ORGANISATION_USERS,
+      params: { organisationId },
       queryParams: queryParams
     },
     headers
@@ -50,7 +40,7 @@ const getUserProfiles = async (userId: string, queryParams?: { [key: string]: st
   return genericFecthGet<UserProfile>(
     {
       baseURL: baseURL,
-      path: endPoints.userProfiles,
+      path: EndPoints.USER_PROFILES,
       queryParams: {
         'user-Id': userId,
         ...queryParams

--- a/src/main/services/tendersService/events/api.ts
+++ b/src/main/services/tendersService/events/api.ts
@@ -10,9 +10,7 @@ const getEvents = async (accessToken: string, projectId: string): Promise<FetchR
     {
       baseURL: baseURL,
       path: EndPoints.EVENTS,
-      params: [
-        [':project-id', projectId]
-      ]
+      params: { projectId }
     },
     headers(accessToken)
   );

--- a/src/main/services/types/agreementsService/api.ts
+++ b/src/main/services/types/agreementsService/api.ts
@@ -1,9 +1,9 @@
 enum EndPoints {
-  AGREEMENT = '/agreements/:agreement-id',
-  AGREEMENT_LOTS = '/agreements/:agreement-id/lots',
-  AGREEMENT_LOT = '/agreements/:agreement-id/lots/:lot-id',
-  AGREEMENT_LOT_SUPPLIERS = '/agreements/:agreement-id/lots/:lot-id/suppliers',
-  AGREEMENT_LOT_EVENT_TYPES = '/agreements/:agreement-id/lots/:lot-id/event-types'
+  AGREEMENT = '/agreements/:agreementId',
+  AGREEMENT_LOTS = '/agreements/:agreementId/lots',
+  AGREEMENT_LOT = '/agreements/:agreementId/lots/:lotId',
+  AGREEMENT_LOT_SUPPLIERS = '/agreements/:agreementId/lots/:lotId/suppliers',
+  AGREEMENT_LOT_EVENT_TYPES = '/agreements/:agreementId/lots/:lotId/event-types'
 }
 
 type AgreementLotEventType = {

--- a/src/main/services/types/contentService/api.ts
+++ b/src/main/services/types/contentService/api.ts
@@ -1,5 +1,5 @@
 enum EndPoints {
-  MENU = '/wp-json/wp-api-menus/v2/menus/:menu-id'
+  MENU = '/wp-json/wp-api-menus/v2/menus/:menuId'
 };
 
 type ContentServiceMenuItem = {

--- a/src/main/services/types/gCloud/service/api.ts
+++ b/src/main/services/types/gCloud/service/api.ts
@@ -1,7 +1,7 @@
 enum EndPoints {
-  SERVICE = '/services/:service-id',
-  SUPPLIER = '/suppliers/:supplier-id',
-  SUPPLIER_FRAMEWORK = '/suppliers/:supplier-id/frameworks/g-cloud-13'
+  SERVICE = '/services/:serviceId',
+  SUPPLIER = '/suppliers/:supplierId',
+  SUPPLIER_FRAMEWORK = '/suppliers/:supplierId/frameworks/g-cloud-13'
 }
 
 type GCloudService = {

--- a/src/main/services/types/helpers/url.ts
+++ b/src/main/services/types/helpers/url.ts
@@ -1,9 +1,14 @@
-
 type FormatURLParams = {
   baseURL: string
   path: string
-  params?: Array<[string, string]>
+  params?: { [key: string]: string }
   queryParams?: { [key: string]: string }
 }
 
-export { FormatURLParams };
+type FormatRelativeURLParams = {
+  path: string
+  params?: { [key: string]: string }
+  queryParams?: { [key: string]: string }
+}
+
+export { FormatURLParams, FormatRelativeURLParams };

--- a/src/main/services/types/publicProcurementGateway/organisation/api.ts
+++ b/src/main/services/types/publicProcurementGateway/organisation/api.ts
@@ -1,3 +1,9 @@
+enum EndPoints {
+  ORGANISATION = '/organisation-profiles/:organisationId',
+  ORGANISATION_USERS = '/organisation-profiles/:organisationId/users',
+  USER_PROFILES = '/user-profiles'
+};
+
 type Organisation = {
   identifier: {
     legalName: string
@@ -15,11 +21,5 @@ type UserProfile = {
   lastName: string
   telephone: string
 }
-
-type EndPoints = {
-  organisation: string
-  organisationUsers: string
-  userProfiles: string
-};
 
 export { Organisation, OrganisationUsers, UserProfile, EndPoints };

--- a/src/main/services/types/tendersService/events/api.ts
+++ b/src/main/services/types/tendersService/events/api.ts
@@ -1,5 +1,5 @@
 enum EndPoints {
-  EVENTS = '/tenders/projects/:project-id/events'
+  EVENTS = '/tenders/projects/:projectId/events'
 }
 
 export { EndPoints };

--- a/src/test/unit/services/contentService/api.test.ts
+++ b/src/test/unit/services/contentService/api.test.ts
@@ -85,7 +85,7 @@ describe('Content service API helpers', () => {
       const findMenuResult = await contentServiceAPI.getMenu(menuId) as FetchResultError;
 
       expect(findMenuResult.status).to.eq(FetchResultStatus.ERROR);
-      expect(findMenuResult.error).to.eql(new FetchTimeoutError(HTTPMethod.GET, baseURL + '/wp-json/wp-api-menus/v2/menus/:menu-id', 15));
+      expect(findMenuResult.error).to.eql(new FetchTimeoutError(HTTPMethod.GET, baseURL + '/wp-json/wp-api-menus/v2/menus/:menuId', 15));
     });
   });
 });

--- a/src/test/unit/services/helpers/api.test.ts
+++ b/src/test/unit/services/helpers/api.test.ts
@@ -47,7 +47,7 @@ describe('fecth helpers', () => {
       });
 
       it('calls get with the formatted URL and the provided headers when there is an id', async () => {
-        const path = '/test/:test-id';
+        const path = '/test/:testId';
 
         mockPool.intercept({
           path: '/test/test-1234',
@@ -58,7 +58,7 @@ describe('fecth helpers', () => {
           {
             baseURL: baseURL,
             path: path,
-            params: [[':test-id', 'test-1234']]
+            params: { testId: 'test-1234' }
           },
           headers
         ) as FetchResultOK<GenericData>;
@@ -92,7 +92,7 @@ describe('fecth helpers', () => {
       });
 
       it('calls get with the formatted URL and the provided headers when there is an id and query params', async () => {
-        const path = '/test/:test-id';
+        const path = '/test/:testId';
         const queryParams = {
           myParam: 'myParam'
         };
@@ -106,7 +106,7 @@ describe('fecth helpers', () => {
           {
             baseURL: baseURL,
             path: path,
-            params: [[':test-id', 'test-1234']],
+            params: { testId: 'test-1234' },
             queryParams: queryParams
           },
           headers
@@ -314,7 +314,7 @@ describe('fecth helpers', () => {
       });
 
       it('calls get with the formatted URL and the provided headers when there is an id', async () => {
-        const path = '/test/:test-id';
+        const path = '/test/:testId';
 
         mockPool.intercept({
           method: 'POST',
@@ -327,7 +327,7 @@ describe('fecth helpers', () => {
           {
             baseURL: baseURL,
             path: path,
-            params: [[':test-id', 'test-1234']]
+            params: { testId: 'test-1234' }
           },
           headers,
           body
@@ -365,7 +365,7 @@ describe('fecth helpers', () => {
       });
 
       it('calls get with the formatted URL and the provided headers when there is an id and query params', async () => {
-        const path = '/test/:test-id';
+        const path = '/test/:testId';
         const queryParams = {
           myParam: 'myParam'
         };
@@ -381,7 +381,7 @@ describe('fecth helpers', () => {
           {
             baseURL: baseURL,
             path: path,
-            params: [[':test-id', 'test-1234']],
+            params: { testId: 'test-1234' },
             queryParams: queryParams
           },
           headers,

--- a/src/test/unit/services/helpers/url.test.ts
+++ b/src/test/unit/services/helpers/url.test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
-import { formatURL } from 'main/services/helpers/url';
+import { formatURL, formatRelativeURL } from 'main/services/helpers/url';
 
 describe('URL helpers', () => {
-  const baseURL = 'http://example.com';
-
   describe('formatURL', () => {
+    const baseURL = 'http://example.com';
+
     it('returns the base url with the path when no other params are passed', () => {
       const path = '/test';
 
@@ -12,15 +12,15 @@ describe('URL helpers', () => {
     });
 
     it('replaces the ids when id params are passed', () => {
-      const path = '/test/:test-id/user/:user-id';
+      const path = '/test/:testId/user/:userId';
 
-      expect(formatURL({ baseURL, path, params: [[':test-id', 'test-1234'], [':user-id', 'user-1234']] })).to.eq('http://example.com/test/test-1234/user/user-1234');
+      expect(formatURL({ baseURL, path, params: { testId: 'test-1234', userId: 'user-1234' } })).to.eq('http://example.com/test/test-1234/user/user-1234');
     });
 
     it('only replaces the params if they are present', () => {
-      const path = '/test/:test-id/user/:user-id';
+      const path = '/test/:testId/user/:userId';
 
-      expect(formatURL({ baseURL, path, params: [[':user-id', 'user-1234']] })).to.eq('http://example.com/test/:test-id/user/user-1234');
+      expect(formatURL({ baseURL, path, params: { userId: 'user-1234' } })).to.eq('http://example.com/test/:testId/user/user-1234');
     });
 
     it('adds the query parameters', () => {
@@ -34,13 +34,53 @@ describe('URL helpers', () => {
     });
 
     it('works when all params are passed', () => {
-      const path = '/test/:test-id/user/:user-id';
+      const path = '/test/:testId/user/:userId';
       const queryParams = {
         test: 'test',
         myParam: 'myParam'
       };
 
-      expect(formatURL({ baseURL, path, params: [[':test-id', 'test-1234'], [':user-id', 'user-1234']], queryParams })).to.eq('http://example.com/test/test-1234/user/user-1234?test=test&myParam=myParam');
+      expect(formatURL({ baseURL, path, params: { testId: 'test-1234', userId: 'user-1234' }, queryParams })).to.eq('http://example.com/test/test-1234/user/user-1234?test=test&myParam=myParam');
+    });
+  });
+
+  describe('formatRelativeURL', () => {
+    it('returns the base url with the path when no other params are passed', () => {
+      const path = '/test';
+
+      expect(formatRelativeURL({ path })).to.eq('/test');
+    });
+
+    it('replaces the ids when id params are passed', () => {
+      const path = '/test/:testId/user/:userId';
+
+      expect(formatRelativeURL({ path, params: { testId: 'test-1234', userId: 'user-1234' } })).to.eq('/test/test-1234/user/user-1234');
+    });
+
+    it('only replaces the params if they are present', () => {
+      const path = '/test/:testId/user/:userId';
+
+      expect(formatRelativeURL({ path, params: { userId: 'user-1234' } })).to.eq('/test/:testId/user/user-1234');
+    });
+
+    it('adds the query parameters', () => {
+      const path = '/test';
+      const queryParams = {
+        test: 'test',
+        myParam: 'myParam'
+      };
+
+      expect(formatRelativeURL({ path, queryParams })).to.eq('/test?test=test&myParam=myParam');
+    });
+
+    it('works when all params are passed', () => {
+      const path = '/test/:testId/user/:userId';
+      const queryParams = {
+        test: 'test',
+        myParam: 'myParam'
+      };
+
+      expect(formatRelativeURL({ path, params: { testId: 'test-1234', userId: 'user-1234' }, queryParams })).to.eq('/test/test-1234/user/user-1234?test=test&myParam=myParam');
     });
   });
 });


### PR DESCRIPTION
### JIRA link

N/A

### Change description

While looking at something else, I realised I could refactor the params part of the URL helper so that it required less lines of code to pass params. I also add the formatRelativeURL helper as I think this will be useful in changes that will be made in future PRs.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
