### PR TITLE
Move performance logging into it's own concern to be sued by the API methods

### DIFF
--- a/src/main/common/middlewares/agreementservice/agreementDetailsFetch.ts
+++ b/src/main/common/middlewares/agreementservice/agreementDetailsFetch.ts
@@ -1,17 +1,10 @@
 import { Handler, Request, Response, NextFunction } from 'express';
-import { Logger } from '@hmcts/nodejs-logging';
 import { AgreementDetail } from '../models/agreement-detail';
 import { agreementsService } from 'main/services/agreementsService';
 import { SessionData } from 'express-session';
-const logger = Logger.getLogger('agreement-details-fetch');
 
 const getAgreementDetail = async (agreementId: string): Promise<AgreementDetail> => {
-  const startTime = performance.now();
-  const agreementDetail = (await agreementsService.api.getAgreement(agreementId)).unwrap();
-
-  logger.info(`Feached agreement details from Agreement service API for ${agreementId} in ${performance.now() - startTime}ms`);
-
-  return agreementDetail;
+  return (await agreementsService.api.getAgreement(agreementId)).unwrap();;
 };
 
 const setAgreementHeader = (req: Request, res: Response, agreementDetail: AgreementDetail): void => {

--- a/src/main/common/middlewares/agreementservice/chooseAgreement.ts
+++ b/src/main/common/middlewares/agreementservice/chooseAgreement.ts
@@ -1,21 +1,12 @@
 import { NextFunction, Request, Response } from 'express';
 import { LotDetail } from '../models/lot-detail';
-import { Logger } from '@hmcts/nodejs-logging';
 import { agreementsService } from 'main/services/agreementsService';
 
-const logger = Logger.getLogger('choose-agreement');
-
 const getAgreementLotDetail = async (agreementId: string): Promise<LotDetail[]> => {
-  const startTime = performance.now();
   const agreementLots = (await agreementsService.api.getAgreementLots(agreementId)).unwrap();
 
-  logger.info(`Feached Lot details from Agreement service API for ${agreementId} in ${performance.now() - startTime}ms`);
-
   const lotDetails = await Promise.all(agreementLots.map(async (lotDetail) => {
-    const startTime = performance.now();
     const agreementLotSuppliers = (await (agreementsService.api.getAgreementLotSuppliers(agreementId, lotDetail.number))).unwrap();
-
-    logger.info(`Feached Lot detail suppliers from Agreement service API for ${agreementId}, lot: ${lotDetail.number} in ${performance.now() - startTime}ms`);
 
     lotDetail.suppliers = `${agreementLotSuppliers.length} suppliers`;
 

--- a/src/main/common/middlewares/eventManagement/activeEvents.ts
+++ b/src/main/common/middlewares/eventManagement/activeEvents.ts
@@ -3,12 +3,9 @@ import { LoggTracer } from '../../logtracer/tracer';
 import { tendersService } from 'main/services/tendersService';
 import { Project } from '../models/tendersService/project';
 import { Request, Response, NextFunction } from 'express';
-import { Logger } from '@hmcts/nodejs-logging';
 import { DashboardPaths } from 'main/features/dashboard/model/dashboardConstants';
 import { objectSet } from '@utils/objectSet';
 import { EventDashboardStatus, EventStatus, EventTypes } from '../models/tendersService/event';
-
-const logger = Logger.getLogger('dashboard');
 
 enum EventGroup {
   OPEN,
@@ -22,10 +19,7 @@ type EventResult = {
 }
 
 const getProjectEvents = async (accessToken: string, project: Project): Promise<EventResult[]> => {
-  const startTime = performance.now();
   const events = (await tendersService.api.events.getEvents(accessToken, String(project.projectId))).unwrap();
-
-  logger.info(`Feached project events from Tenders API for ${project.projectId} in ${performance.now() - startTime}ms`);
 
   return events.map((event): EventResult => {
     if (event === undefined) {
@@ -220,10 +214,7 @@ const getEvents = async (req: Request, res: Response, next: NextFunction) => {
   req.session['isTimelineRevert'] = false;
 
   try {
-    const startTime = performance.now();
     const projects = (await tendersService.api.projects.getProjects(accessToken)).unwrap();
-
-    logger.info(`Feached projects from Tenders API in ${performance.now() - startTime}ms`);
 
     const projectEventsCollection = (await Promise.all(projects.map(async (project) => await getProjectEvents(accessToken, project)))).flat();
 
@@ -264,15 +255,12 @@ const searchEvents = async (req: Request, res: Response, next: NextFunction) => 
       ];
 
       const projectCollections = await Promise.all(searchTypes.map(async (searchType) => {
-        const startTime = performance.now();
         const projects = (await tendersService.api.projects.getProjects(accessToken, {
           'search-type': searchType,
           'search-term': `*${searchNew}*`,
           'page': '0',
           'page-size': '20'
         })).unwrap();
-
-        logger.info(`Feached projects from Tenders API for search type ${searchType} in ${performance.now() - startTime}ms`);
 
         return projects;
       }));

--- a/src/main/common/middlewares/menu-contentservice/contentservice.ts
+++ b/src/main/common/middlewares/menu-contentservice/contentservice.ts
@@ -3,10 +3,7 @@ import FileIOSystem from 'fs';
 import config from 'config';
 import { operations } from '../../../utils/operations/operations';
 import { LoggTracer } from '../../logtracer/tracer';
-import { Logger } from '@hmcts/nodejs-logging';
 import { contentService } from 'main/services/contentService';
-
-const logger = Logger.getLogger('contentService');
 
 export class ContentFetchMiddleware {
   static MenuContentFilePath = config.get('contentService.menuDirectory')?.toString();
@@ -18,12 +15,9 @@ export class ContentFetchMiddleware {
     try {
       const allMenuIdentifiersId = ['21', '22', '23', '24', '25'];
       const menuItemsStorage = await Promise.all(allMenuIdentifiersId.map(async (menuId) => {
-        const startTime = performance.now();
-        const menu = (await contentService.api.getMenu(menuId)).unwrap();
-      
-        logger.info( `Feached menu from the content service API for menu ${menuId} in ${performance.now() - startTime}ms`);
-  
+        const menu = (await contentService.api.getMenu(menuId)).unwrap();  
         const { ID, name } = menu;
+
         return {
           ID: ID,
           name: name,

--- a/src/main/services/agreementsService/api.ts
+++ b/src/main/services/agreementsService/api.ts
@@ -26,6 +26,10 @@ const getAgreement = async (agreementId: string): Promise<FetchResult<AgreementD
     {
       key: `get_agreements_${agreementId}`,
       seconds: agreementServiceCacheLength
+    },
+    {
+      name: 'agreement service',
+      message: `Feached agreement from the Agreement service API for agreement: ${agreementId}`
     }
   );
 };
@@ -42,6 +46,10 @@ const getAgreementLots = async (agreementId: string): Promise<FetchResult<LotDet
     {
       key: `get_agreements_${agreementId}_lots`,
       seconds: agreementServiceCacheLength
+    },
+    {
+      name: 'agreement service',
+      message: `Feached agreement lots from the Agreement service API for agreement: ${agreementId}`
     }
   );
 };
@@ -58,6 +66,10 @@ const getAgreementLot = async (agreementId: string, lotId: string): Promise<Fetc
     {
       key: `get_agreements_${agreementId}_lots_${lotId}`,
       seconds: agreementServiceCacheLength
+    },
+    {
+      name: 'agreement service',
+      message: `Feached agreement lot from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
     }
   );
 };
@@ -74,6 +86,10 @@ const getAgreementLotSuppliers = async (agreementId: string, lotId: string): Pro
     {
       key: `get_agreements_${agreementId}_lots_${lotId}_suppliers`,
       seconds: 900
+    },
+    {
+      name: 'agreement service',
+      message: `Feached agreement lot suppliers from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
     }
   );
 };
@@ -90,6 +106,10 @@ const getAgreementLotEventTypes = async (agreementId: string, lotId: string): Pr
     {
       key: `get_agreements_${agreementId}_lots_${lotId}_event_types`,
       seconds: agreementServiceCacheLength
+    },
+    {
+      name: 'agreement service',
+      message: `Feached agreement lot event types from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
     }
   );
 };

--- a/src/main/services/contentService/api.ts
+++ b/src/main/services/contentService/api.ts
@@ -21,6 +21,10 @@ const getMenu = async (menuId: string): Promise<FetchResult<ContentServiceMenu>>
       key: `get_content_service_menu_${menuId}`,
       seconds: 3600
     },
+    {
+      name: 'content service',
+      message: `Feached menu from the Content service API for menu: ${menuId}`
+    },
     timeout
   );
 };

--- a/src/main/services/helpers/chache.ts
+++ b/src/main/services/helpers/chache.ts
@@ -1,0 +1,29 @@
+import { createRedisClient } from 'main/setup/redis/client';
+import { CacheOptions } from '../types/helpers/cache';
+
+const getCachedData = async <T>(key: string): Promise<T | null> => {
+  const client = createRedisClient();
+
+  await client.connect();
+
+  const dataString = await client.get(key);
+  const data = dataString ? JSON.parse(dataString) : dataString;
+
+  await client.disconnect();
+
+  return data;
+};
+
+const setCachedData = async <T>(data: T, cacheOptions: CacheOptions): Promise<void> => {
+  const client = createRedisClient();
+
+  await client.connect();
+
+  await client.set(cacheOptions.key, JSON.stringify(data), {
+    EX: cacheOptions.seconds
+  });
+
+  await client.disconnect();
+};
+
+export { getCachedData, setCachedData };

--- a/src/main/services/helpers/performanceLogger.ts
+++ b/src/main/services/helpers/performanceLogger.ts
@@ -1,0 +1,36 @@
+import { Logger } from '@hmcts/nodejs-logging';
+import { LoggerInstance, LoggerOptions, PerformanceLoggerInterface } from '../types/helpers/performanceLogger';
+
+class FakePerformanceLogger implements PerformanceLoggerInterface {
+  startTimer = (): void => { return undefined; };
+  endTimerAndLogResult = (): void => { return undefined; };
+}
+
+class PerfomanceLogger implements PerformanceLoggerInterface {
+  private startTime: number;
+  private logger: LoggerInstance;
+  private message: string;
+  
+  constructor(loggerOptions: LoggerOptions) {
+    this.logger = Logger.getLogger(loggerOptions.name);
+    this.message = loggerOptions.message;
+  }
+
+  startTimer = () => {
+    this.startTime = performance.now();
+  };
+
+  endTimerAndLogResult = () => {
+    this.logger.info(`${this.message} in ${performance.now() - this.startTime}ms`);
+  };
+}
+
+const getPerformanceLogger = (loggerOptions?: LoggerOptions) => {
+  if (loggerOptions) {
+    return new PerfomanceLogger(loggerOptions);
+  } else {
+    return new FakePerformanceLogger();
+  }
+};
+
+export { getPerformanceLogger };

--- a/src/main/services/tendersService/events/api.ts
+++ b/src/main/services/tendersService/events/api.ts
@@ -12,7 +12,12 @@ const getEvents = async (accessToken: string, projectId: string): Promise<FetchR
       path: EndPoints.EVENTS,
       params: { projectId }
     },
-    headers(accessToken)
+    headers(accessToken),
+    undefined,
+    {
+      name: 'tenders API',
+      message: `Feached project events from the Tenders API for project: ${projectId}`
+    }
   );
 };
 

--- a/src/main/services/tendersService/projects/api.ts
+++ b/src/main/services/tendersService/projects/api.ts
@@ -12,7 +12,12 @@ const getProjects = async (accessToken: string, queryParams?: { [key: string]: s
       path: EndPoints.PROJECTS,
       queryParams: queryParams
     },
-    headers(accessToken)
+    headers(accessToken),
+    undefined,
+    {
+      name: 'tenders API',
+      message: 'Feached projects from the Tenders API'
+    }
   );
 };
 

--- a/src/main/services/types/helpers/api.ts
+++ b/src/main/services/types/helpers/api.ts
@@ -3,11 +3,6 @@ enum HTTPMethod {
   POST = 'POST'
 }
 
-type CacheOptions = {
-  key: string
-  seconds: number
-}
-
 interface FetchRequestInit extends Omit<RequestInit, 'method'> {
   method: HTTPMethod
 }
@@ -33,4 +28,4 @@ type FetchResult<T> = BaseFetchResult<T> & {
   unwrap: () => T
 }
 
-export { HTTPMethod, CacheOptions, FetchRequestInit, BaseFetchResult, FetchResult, FetchResultStatus, FetchResultOK, FetchResultError };
+export { HTTPMethod, FetchRequestInit, BaseFetchResult, FetchResult, FetchResultStatus, FetchResultOK, FetchResultError };

--- a/src/main/services/types/helpers/cache.ts
+++ b/src/main/services/types/helpers/cache.ts
@@ -1,0 +1,6 @@
+type CacheOptions = {
+  key: string
+  seconds: number
+}
+
+export { CacheOptions };

--- a/src/main/services/types/helpers/performanceLogger.ts
+++ b/src/main/services/types/helpers/performanceLogger.ts
@@ -1,0 +1,15 @@
+type LoggerOptions = {
+  name: string
+  message: string
+}
+
+type LoggerInstance = {
+  info: (message: string) => void
+}
+
+interface PerformanceLoggerInterface {
+  startTimer: () => void
+  endTimerAndLogResult: () => void
+}
+
+export { LoggerOptions, LoggerInstance, PerformanceLoggerInterface };

--- a/src/test/unit/services/agreementsService/api.test.ts
+++ b/src/test/unit/services/agreementsService/api.test.ts
@@ -8,6 +8,7 @@ import { agreementsServiceAPI } from 'main/services/agreementsService/api';
 import { FetchResultOK, FetchResultStatus } from 'main/services/types/helpers/api';
 import { Interceptable, MockAgent, setGlobalDispatcher } from 'undici';
 import { assertRedisCalls, assertRedisCallsWithCache, creatRedisMockSpy } from 'test/utils/mocks/redis';
+import { assertPerformanceLoggerCalls, creatPerformanceLoggerMockSpy } from 'test/utils/mocks/performanceLogger';
 
 describe('Agrements Service API helpers', () => {
   const mock = Sinon.createSandbox();
@@ -34,8 +35,12 @@ describe('Agrements Service API helpers', () => {
     const data = { name: 'myName', endDate: 'myEndDate' };
 
     describe('when no data is cached', () => {
-      it('calls the get agreement endpoint with the correct url and headers', async () => {
+      it('calls the get agreement endpoint with the correct url and headers and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement from the Agreement service API for agreement: ${agreementId}`
+        });
 
         mockPool.intercept({
           method: 'GET',
@@ -49,12 +54,17 @@ describe('Agrements Service API helpers', () => {
         expect(findAgreementResult.data).to.eql(data);
 
         assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234', data, 3600);
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
 
     describe('when data is cached', () => {
-      it('does not call the get agreement endpoint but still returns the data', async () => {
+      it('does not call the get agreement endpoint but still returns the data and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement from the Agreement service API for agreement: ${agreementId}`
+        });
 
         const findAgreementResult = await agreementsServiceAPI.getAgreement(agreementId) as FetchResultOK<AgreementDetail>;
 
@@ -62,6 +72,7 @@ describe('Agrements Service API helpers', () => {
         expect(findAgreementResult.data).to.eql(data);
 
         assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234');
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
   });
@@ -84,8 +95,12 @@ describe('Agrements Service API helpers', () => {
     ];
 
     describe('when no data is cached', () => {
-      it('calls the get agreement lots endpoint with the correct url and headers', async () => {
+      it('calls the get agreement lots endpoint with the correct url and headers and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement lots from the Agreement service API for agreement: ${agreementId}`
+        });
 
         mockPool.intercept({
           method: 'GET',
@@ -99,12 +114,17 @@ describe('Agrements Service API helpers', () => {
         expect(getAgreementLotsResult.data).to.eql(data);
 
         assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots', data, 3600);
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
 
     describe('when data is cached', () => {
-      it('does not call the get agreement lots endpoint but still returns the data', async () => {
+      it('does not call the get agreement lots endpoint but still returns the data and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement lots from the Agreement service API for agreement: ${agreementId}`
+        });
 
         const getAgreementLotsResult = await agreementsServiceAPI.getAgreementLots(agreementId) as FetchResultOK<LotDetail[]>;
 
@@ -112,6 +132,7 @@ describe('Agrements Service API helpers', () => {
         expect(getAgreementLotsResult.data).to.eql(data);
 
         assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots');
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
   });
@@ -133,8 +154,12 @@ describe('Agrements Service API helpers', () => {
     };
 
     describe('when no data is cached', () => {
-      it('calls the get agreement lot endpoint with the correct url and headers', async () => {
+      it('calls the get agreement lot endpoint with the correct url and headers and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement lot from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
+        });
 
         mockPool.intercept({
           method: 'GET',
@@ -148,12 +173,17 @@ describe('Agrements Service API helpers', () => {
         expect(findAgreementLotResult.data).to.eql(data);
 
         assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234', data, 3600);
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
 
     describe('when data is cached', () => {
-      it('does not call the get agreement lot endpoint but still returns the data', async () => {
+      it('does not call the get agreement lot endpoint but still returns the data and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement lot from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
+        });
 
         const findAgreementLotResult = await agreementsServiceAPI.getAgreementLot(agreementId, lotId) as FetchResultOK<LotDetail>;
 
@@ -161,6 +191,7 @@ describe('Agrements Service API helpers', () => {
         expect(findAgreementLotResult.data).to.eql(data);
 
         assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234');
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
   });
@@ -191,8 +222,12 @@ describe('Agrements Service API helpers', () => {
     ];
 
     describe('when no data is cached', () => {
-      it('calls the get agreement lot suppliers endpoint with the correct url and headers', async () => {
+      it('calls the get agreement lot suppliers endpoint with the correct url and headers and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement lot suppliers from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
+        });
 
         mockPool.intercept({
           method: 'GET',
@@ -206,12 +241,17 @@ describe('Agrements Service API helpers', () => {
         expect(getAgreementLotSuppliersResult.data).to.eql(data);
 
         assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234_suppliers', data, 900);
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
 
     describe('when data is cached', () => {
-      it('does not call the get agreement lot suppliers endpoint but still returns the data', async () => {
+      it('does not call the get agreement lot suppliers endpoint but still returns the data and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement lot suppliers from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
+        });
 
         const getAgreementLotSuppliersResult = await agreementsServiceAPI.getAgreementLotSuppliers(agreementId, lotId) as FetchResultOK<LotSupplier[]>;
 
@@ -219,6 +259,7 @@ describe('Agrements Service API helpers', () => {
         expect(getAgreementLotSuppliersResult.data).to.eql(data);
 
         assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234_suppliers');
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
   });
@@ -228,8 +269,12 @@ describe('Agrements Service API helpers', () => {
     const data = [{ type: 'myType' }];
 
     describe('when no data is cached', () => {
-      it('calls the get agreement lot event types endpoint with the correct url and headers', async () => {
+      it('calls the get agreement lot event types endpoint with the correct url and headers and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement lot event types from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
+        });
 
         mockPool.intercept({
           method: 'GET',
@@ -243,12 +288,17 @@ describe('Agrements Service API helpers', () => {
         expect(getAgreementLotEventTypesResult.data).to.eql(data);
 
         assertRedisCalls(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234_event_types', data, 3600);
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
 
     describe('when data is cached', () => {
-      it('does not call the get agreement lot event types endpoint but still returns the data', async () => {
+      it('does not call the get agreement lot event types endpoint but still returns the data and logs the performance', async () => {
         const mockRedisClientSpy = creatRedisMockSpy(mock, data);
+        const mockedPerformanceLoggerSpy = creatPerformanceLoggerMockSpy(mock, {
+          name: 'agreement service',
+          message: `Feached agreement lot event types from the Agreement service API for agreement: ${agreementId}, lot: ${lotId}`
+        });
 
         const getAgreementLotEventTypesResult = await agreementsServiceAPI.getAgreementLotEventTypes(agreementId, lotId) as FetchResultOK<AgreementLotEventType[]>;
 
@@ -256,6 +306,7 @@ describe('Agrements Service API helpers', () => {
         expect(getAgreementLotEventTypesResult.data).to.eql(data);
 
         assertRedisCallsWithCache(mockRedisClientSpy, 'get_agreements_agreementId-1234_lots_lotId-1234_event_types');
+        assertPerformanceLoggerCalls(mockedPerformanceLoggerSpy);
       });
     });
   });

--- a/src/test/utils/mocks/performanceLogger.ts
+++ b/src/test/utils/mocks/performanceLogger.ts
@@ -1,0 +1,30 @@
+import * as performanceLogger from 'main/services/helpers/performanceLogger';
+import Sinon from 'sinon';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import { LoggerOptions } from 'main/services/types/helpers/performanceLogger';
+
+chai.use(sinonChai);
+
+const mockPerformanceLogger = {
+  startTimer: () => {
+    // Mocks the start timer call
+  },
+  endTimerAndLogResult: () => {
+    // Mocks the end timer call
+  }
+};
+
+const creatPerformanceLoggerMockSpy = (mock: Sinon.SinonSandbox, loggerOptions?: LoggerOptions) => {
+  const mockedPerformanceLoggerSpy = mock.spy(mockPerformanceLogger);
+  mock.stub(performanceLogger, 'getPerformanceLogger').withArgs(loggerOptions).returns(mockPerformanceLogger);
+
+  return mockedPerformanceLoggerSpy;
+};
+
+const assertPerformanceLoggerCalls = (mockedPerformanceLoggerSpy: Sinon.SinonSpiedInstance<typeof mockPerformanceLogger>) => {
+  expect(mockedPerformanceLoggerSpy.startTimer).to.have.been.calledOnce;
+  expect(mockedPerformanceLoggerSpy.endTimerAndLogResult).to.have.been.calledOnce;
+};
+
+export { creatPerformanceLoggerMockSpy, assertPerformanceLoggerCalls };


### PR DESCRIPTION
### JIRA link

N/A

### Change description

While looking at some other work I decided to refactor the `genericFetch` method to include the logging of the performance automatically. It’s quite useful to log how long it takes to make an API request so we can workout performance bottlenecks. It’s also a good sanity check when writing asynchronous code that it does, in fact, execute asynchronously.

I’ve moved the logging and caching into their own files just to separate the concerns a little. I’ve removed the places in the code where we were logging the performance as they are no longer required. Finally, I have added tests to make sure that we do log as expected.

### Work checklist

- [x] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
