### PR TITLE
CAS-1620 - Show trading name for MCF3 supplier list

### DIFF
--- a/src/main/features/fca/views/fca_supplier_list.njk
+++ b/src/main/features/fca/views/fca_supplier_list.njk
@@ -98,10 +98,13 @@
 					{% for item in suppliers_list %}
 						<li>
 							<h3 class="govuk-heading-m ccs-heading-link ccs-font-weight-semibold govuk-!-font-size-24">
-								{# <a href="/fca/supplier/ratecard?supplierId={{item.organization.id}}&supplierName={{item.organization.name}}">{{item.organization.name}}</a> #}
-							{{item.organization.name}}
+								{{ item.organization.name }}
 							</h3>
-							<p class="govuk-list govuk-!-font-size-17featured ccs-framework-list">{{item.organization.name}}</p>
+							{% if item.organization.details.tradingName and item.organization.details.tradingName !== item.organization.name %}
+								<p class="govuk-list govuk-!-font-size-17featured ccs-framework-list">
+									Trading as {{ item.organization.details.tradingName }}
+								</p>
+							{% endif %}
 						</li>
 					{% else %}
 						<p class="govuk-list govuk-!-font-size-17featured ccs-framework-list">Datas Not Found !</p>


### PR DESCRIPTION
### JIRA link

[CAS-1620](https://crowncommercialservice.atlassian.net/browse/CAS-1620)

### Change description

On the supplier list page for MCF, if the supplier has a trading name and it is different from their legal name then we will show it under the legal name with a prefix of “Trading as ”

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


[CAS-1620]: https://crowncommercialservice.atlassian.net/browse/CAS-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ