### PR TITLE
CAS-1634 -Show trading name for MCF3 supplier results DA

### DIFF
--- a/src/main/features/da/views/daw-suppliers.njk
+++ b/src/main/features/da/views/daw-suppliers.njk
@@ -1,15 +1,13 @@
 {% extends "template.njk" %}
 {% from "macros/csrf.njk" import csrfProtection %}
 {% set title = 'Suppliers you want to approach | Crown Commercial Service' %}
-
 {% block breadCrumb %}
- {% if(enablebtn) %}
-    {{ CCSBreadcrumbs({
+    {% if(enablebtn) %}
+        {{ CCSBreadcrumbs({
         items: data.breadCrumbs
       }) }}
-      {% endif %}
+    {% endif %}
 {% endblock %}
-
 {% block content %}
     <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
         {% if(error) %}
@@ -21,20 +19,18 @@
                     }
                 ]
             }) }}
-        {%endif %}
+        {% endif %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <h1 class="govuk-heading-xl">
-                    {{data.title }}
+                    {{ data.title }}
                 </h1>
             </div>
         </div>
-
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full govuk-grid-column-two-thirds-from-desktop">
                 {% include "includes/project_header.njk" %}
-                <p class="govuk-body govuk-!-margin-bottom-7">{{data.subtitle}}</p>
-
+                <p class="govuk-body govuk-!-margin-bottom-7">{{ data.subtitle }}</p>
                 {% if agreementId_session == "RM6187" %}
                     <p class="govuk-body">
                         Find more information on each supplier on the
@@ -44,52 +40,59 @@
                             </a>
                         </b>
                     </p>
-                {% else %}  
-                    <p class="govuk-body">{{data.subtitle1 | safe}}</p>
+                {% else %}
+                    <p class="govuk-body">{{ data.subtitle1 | safe }}</p>
                 {% endif %}
-              <form id="ccs-rfp-suppliers-form" class="ccs-rfp-suppliers-form" action="/da/suppliers" method="POST">
-                {{ csrfProtection(csrf) }}
+                <form id="ccs-rfp-suppliers-form" class="ccs-rfp-suppliers-form" action="/da/suppliers" method="POST">
+                    {{ csrfProtection(csrf) }}
                     <br>
-                    <h2 class="govuk-heading-m">
-                        <span id="added_suppliers_count">
-                            {{supplierLength}}
-                        </span> suppliers on this lot </h2>
-                    <br>
-                    {% if(enablebtn) %}
-                    <div class="govuk-button-group govuk-!-margin-bottom-7">
-                        {{ CCSButton({
+                        <h2 class="govuk-heading-m">
+                            <span id="added_suppliers_count">
+                                {{ supplierLength }}
+                            </span>
+                            suppliers on this lot
+                        </h2>
+                        <br>
+                            {% if(enablebtn) %}
+                                <div class="govuk-button-group govuk-!-margin-bottom-7">
+                                    {{ CCSButton({
                 text: "Save and continue"
                 }) }}
-                        <a href="{{data.backJump.href}}" class="govuk-link govuk-link--no-visited-state">{{data.backJump.title}}</a>
-                    </div>
-                    {% endif %}
-                    <div class="govuk-form-group ccs-page-section"></div>
-                    <div id="page1" >
-                        <div id="supplier-list">
-                            <div class="govuk-form-group ccs-page-section">
-                                <h3>
-                                    <a href="/da/suppliers?download=1" onclick="return true;" class="govuk-link govuk-link--no-visited-state">Download this list</a>
-                                </h3>
-                            </div>
-                            {% set formOptions = suppliers_list %}
-                            {% set form_Options_Altered = [] %}
-                            
-                            {% for item in formOptions %}
-                            {% set radioCheckSession = '' %}
-                            
-                            {% if item.organization.id == radioSelected %}
-                                {% set radioCheckSession = 'checked' %}
-                            {% else %}
-                                {% set radioCheckSession = '' %}
+                                    <a href="{{ data.backJump.href }}" class="govuk-link govuk-link--no-visited-state">{{ data.backJump.title }}</a>
+                                </div>
                             {% endif %}
-                            
-                            {% set returnLink %}
-                                <p>{{item.organization.identifier.legalName}}</p>
-                                 {% if(enablebtn) %}
-                                <p> <a href="/da/supplier/ratecard?supplierId={{item.organization.id}}&supplierName={{item.organization.name}}">View rate card and contact details</a></p>
-                                 {% endif %}
-                            {% endset %}
-                            {% set form_Options_Altered = (form_Options_Altered.push(
+                            <div class="govuk-form-group ccs-page-section"></div>
+                            <div id="page1">
+                                <div id="supplier-list">
+                                    <div class="govuk-form-group ccs-page-section">
+                                        <h3>
+                                            <a href="/da/suppliers?download=1" onclick="return true;" class="govuk-link govuk-link--no-visited-state">Download this
+                                                list</a>
+                                        </h3>
+                                    </div>
+                                    {% set formOptions = suppliers_list %}
+                                    {% set form_Options_Altered = [] %}
+                                    {% for item in formOptions %}
+                                        {% set radioCheckSession = '' %}
+                                        {% if item.organization.id == radioSelected %}
+                                            {% set radioCheckSession = 'checked' %}
+                                        {% else %}
+                                            {% set radioCheckSession = '' %}
+                                        {% endif %}
+                                        {% set returnLink %}
+                                        {% if item.organization.details.tradingName and item.organization.details.tradingName !== item.organization.name %}
+                                            <p>
+                                                Trading as {{ item.organization.details.tradingName }}
+                                            </p>
+                                        {% endif %}
+                                        {% if(enablebtn) %}
+                                            <p>
+                                                <a href="/da/supplier/ratecard?supplierId={{ item.organization.id }}&supplierName={{ item.organization.name }}">View
+                                                    rate card and contact details</a>
+                                            </p>
+                                        {% endif %}
+                                        {% endset %}
+                                        {% set form_Options_Altered = (form_Options_Altered.push(
                                 {
                                     value: item.organization.id,
                                     html: "<h3 class='govuk-heading-m'>" + item.organization.name + "</h3>",
@@ -97,87 +100,72 @@
                                         html: returnLink
                                     },
                                     checked: radioCheckSession
-                                }), form_Options_Altered) 
-                                %}
-                            {% endfor %}
-                            
-                            
-                            {{ CCSRadios({
+                                }), form_Options_Altered) %}
+                                    {% endfor %}
+                                    {{ CCSRadios({
                                 classes: "govuk-radios--small govuk-radios--supplier",
                                 idPrefix: "supplier_list",
                                 name: "supplier_list",
                                 items: form_Options_Altered
-                              }) }}  
-
-                            
-                            {#{% for supplier in suppliers_list %}
-                            {% if(enablebtn) %}
-                                {{ CCSRadios({
-                                    idPrefix: "fc_rfp_type",
-                                    name: "test",
-                                    items: "test items"
-                                }) }}
-                                {% endif %}
-                                <div class="govuk-form-group ccs-page-section">
-                                    <h3 class="govuk-heading-m">{{supplier.organization.name}}</h3>
-                                    <div id="rfp_required_suppliers-item-hint" class="">
-                                        {% if supplier.organization.identifier.legalName | length > 0 %}   
-                                            <p>{{supplier.organization.identifier.legalName}}</p>
-                                            {% if(enablebtn) %}
-                                            <p> <a href="/da/supplier/ratecard?supplierId={{supplier.organization.id}}&supplierName={{supplier.organization.name}}">View rate card and contact details</a></p>
-                                            {% endif %}
-                                            <br>
-                                        {% endif %}
-                                    </div>
+                              }) }}
+                                    {#{% for supplier in suppliers_list %}
+                                                                                                                                        {% if(enablebtn) %}
+                                                                                                                                            {{ CCSRadios({
+                                                                                                                                                idPrefix: "fc_rfp_type",
+                                                                                                                                                name: "test",
+                                                                                                                                                items: "test items"
+                                                                                                                                            }) }}
+                                                                                                                                            {% endif %}
+                                                                                                                                            <div class="govuk-form-group ccs-page-section">
+                                                                                                                                                <h3 class="govuk-heading-m">{{supplier.organization.name}}</h3>
+                                                                                                                                                <div id="rfp_required_suppliers-item-hint" class="">
+                                                                                                                                                    {% if supplier.organization.identifier.legalName | length > 0 %}   
+                                                                                                                                                        <p>{{supplier.organization.identifier.legalName}}</p>
+                                                                                                                                                        {% if(enablebtn) %}
+                                                                                                                                                        <p> <a href="/da/supplier/ratecard?supplierId={{supplier.organization.id}}&supplierName={{supplier.organization.name}}">View rate card and contact details</a></p>
+                                                                                                                                                        {% endif %}
+                                                                                                                                                        <br>
+                                                                                                                                                    {% endif %}
+                                                                                                                                                </div>
+                                                                                                                                            </div>
+                                                                                                                                        {% endfor %}#}
                                 </div>
-                            {% endfor %}#}
-                        </div>
-                    </div>
-                <div>
-                    </br>
-        {% if(showPrevious) %}
-            {% if(enablebtn) %}
-          <a href="suppliers?previous=1" class="govuk-link govuk-link--no-visited-state"><- Previous Page</a>
-          {% else %}
-          <a href="suppliers?fromMessage=1&previous=1" class="govuk-link govuk-link--no-visited-state"><- Previous Page</a>
-          {% endif %}
-          {% endif %}
-          
-          {% if(showNext) %}
-          
-          {% if(enablebtn) %}
-          <a href="suppliers?next=1" class="govuk-link govuk-link--no-visited-state anchor-right">-> Next Page</a>
-          {% else %}
-          <a href="suppliers?fromMessage=1&next=1" class="govuk-link govuk-link--no-visited-state anchor-right">-> Next Page</a>
-          {% endif %}
-          {% endif %}
-
-          </div><br>
-          <div>
-          {% if(showPrevious) %}
-          <label>{{currentpagenumber}} of {{noOfPages}}</label>
-          {% endif %}
-          {% if(showNext) %}
-          <label class="anchor-right">{{currentpagenumber}} of {{noOfPages}}</label>
-          {% endif %}
-          </div>
-          </br>  </br>
-          {% if(enablebtn) %}
-                    {# <div class="govuk-button-group">
-                        {{ CCSButton({
-                text: "Save and continue"
-                }) }}
-                        <a href="{{data.backJump.href}}" class="govuk-link govuk-link--no-visited-state">{{data.backJump.title}}</a>
-                    </div> #}
-                    {% endif %}
-                </form>
-
+                            </div>
+                            <div></br>
+                            {% if(showPrevious) %}
+                                {% if(enablebtn) %}
+                                    <a href="suppliers?previous=1" class="govuk-link govuk-link--no-visited-state">
+                                        <-<-- Previous Page</a> {% else %} <a href="suppliers?fromMessage=1&previous=1" class="govuk-link govuk-link--no-visited-state"> Previous Page</a> {% endif %} {% endif %} {% if(showNext) %} {% if(enablebtn) %} <a href="suppliers?next=1" class="govuk-link govuk-link--no-visited-state anchor-right">>
+                                            Next Page</a>
+                                    {% else %}
+                                        <a href="suppliers?fromMessage=1&next=1" class="govuk-link govuk-link--no-visited-state anchor-right">-> Next Page</a>
+                                    {% endif %}
+                                {% endif %}
+                            </div>
+                            <br>
+                                <div>
+                                    {% if(showPrevious) %}
+                                        <label>{{ currentpagenumber }} of {{ noOfPages }}</label>
+                                    {% endif %}
+                                    {% if(showNext) %}
+                                        <label class="anchor-right">{{ currentpagenumber }} of {{ noOfPages }}</label>
+                                    {% endif %}
+                                </div>
+                            </br>
+                        </br>
+                        {% if(enablebtn) %}
+                            {# <div class="govuk-button-group">
+                                                                                                            {{ CCSButton({
+                                                                                                    text: "Save and continue"
+                                                                                                    }) }}
+                                                                                                            <a href="{{data.backJump.href}}" class="govuk-link govuk-link--no-visited-state">{{data.backJump.title}}</a>
+                                                                                                        </div> #}
+                        {% endif %}
+                    </form>
+                </div>
+                <div class="govuk-grid-column-one-third">
+                    {{ CCSReleatedContent(releatedContent) }}
+                </div>
             </div>
-            <div class="govuk-grid-column-one-third">
-                {{ CCSReleatedContent(releatedContent) }}
-            </div>
-        </div>
-
-    </main>
-
-{% endblock %}
+        </main>
+    {% endblock %}


### PR DESCRIPTION
### JIRA link

[CAS-1634](https://crowncommercialservice.atlassian.net/browse/CAS-1634)

### Change description

On the supplier result page for MCF DA, if the supplier has a trading name and it is different from their legal name then we will show it under the legal name with a prefix of “Trading as ”

I've also formatted the view file to make it more clear what is going on.

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


[CAS-1634]: https://crowncommercialservice.atlassian.net/browse/CAS-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ