### PR TITLE
CAS-1636 - Show trading name for MCF3 list EOI

### DIFF
--- a/src/main/features/eoi/views/suppliers.njk
+++ b/src/main/features/eoi/views/suppliers.njk
@@ -97,9 +97,8 @@
                     <div class="govuk-form-group ccs-page-section govuk-!-padding-bottom-6 govuk-!-margin-bottom-5">
                       <h3 class="govuk-heading-m">{{supplier.organization.name}}</h3>
                       <div id="rfi_required_suppliers-item-hint" class="govuk-hint">
-                        {% if supplier.organization.identifier.legalName | length > 0 %}
-                          <label>{{supplier.organization.identifier.legalName}}</label>
-                          <br>
+                        {% if supplier.organization.details.tradingName and supplier.organization.details.tradingName !== supplier.organization.name %}
+                          Trading as {{ supplier.organization.details.tradingName }}
                         {% endif %}
                       </div>
                     </div>


### PR DESCRIPTION
### JIRA link

[CAS-1636](https://crowncommercialservice.atlassian.net/browse/CAS-1636)

### Change description

On the supplier result page for MCF EOI, if the supplier has a trading name and it is different from their legal name then we will show it under the legal name with a prefix of “Trading as ”

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


[CAS-1636]: https://crowncommercialservice.atlassian.net/browse/CAS-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ