### PR TITLE
CAS-1638 - Show trading name for MCF3 list PA

### DIFF
--- a/src/main/features/fca/views/shortlist_service.njk
+++ b/src/main/features/fca/views/shortlist_service.njk
@@ -80,7 +80,11 @@
       {% for value in suppliers_list -%}
       <div class="govuk-form-group ccs-page-section">
         <h3 class="govuk-heading-m">{{value.organization.name}}</h3>
-        <p>{{value.organization.name}}</p>
+        {% if value.organization.details.tradingName and value.organization.details.tradingName !== value.organization.name %}
+          <p>
+            Trading as {{ value.organization.details.tradingName }}
+          </p>
+        {% endif %}
         <p>
           <a href="/fca/supplier/ratecard?supplierId={{value.organization.id}}&supplierName={{value.organization.name}}" class="govuk-link govuk-link--no-visited-state">{{data.line17}}</a>
         </p>


### PR DESCRIPTION
### JIRA link

[CAS-1638](https://crowncommercialservice.atlassian.net/browse/CAS-1638)

### Change description

On the supplier result page for MCF PA, if the supplier has a trading name and it is different from their legal name then we will show it under the legal name with a prefix of “Trading as ”


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


[CAS-1638]: https://crowncommercialservice.atlassian.net/browse/CAS-1638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ