### PR TITLE
When destroying the session, only log to rollbar if there is an error

### DIFF
--- a/src/main/features/auth/controller/logout.ts
+++ b/src/main/features/auth/controller/logout.ts
@@ -13,7 +13,7 @@ const logger = Logger.getLogger('logout');
  */
 export const LOGOUT = (req: Request, res: Response) => {
   req.session.destroy((error) => {
-    rollbarLogger(error, logger);
+    if (error) rollbarLogger(error, logger);
   });
 
   const redirectURL = ppg.url.oAuth.login(req);


### PR DESCRIPTION
### JIRA link

N/A

### Change description

When destroying the session, only log to rollbar if there is an error

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [x] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
