### PR TITLE
Change `queryParam` type for API services

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,28 +86,17 @@ Run all the test case:
 $ npm test
 ```
 
-Run the routes test case:
-
-```bash
-$ npm run test:routes
-```
-
-Run the unit test case:
-
-```bash
-$ npm run test:unit
-```
-
 Run the accessibility test case:
+
+**NOTE:** currently not enabled
 
 ```bash
 $ npm run test:a11y
 ```
+
 Make sure all the paths in your application are covered by accessibility tests (see [a11y.ts](src/test/a11y/a11y.ts)).
 
 ### Test coverage
-
-**NOTE:** due to a memory issue, the cause of which is currently unknown, this script does not yet work
 
 We use [Instanbul nyc](https://github.com/istanbuljs/nyc).
 

--- a/src/main/features/da/controller/da-addcollaborator.ts
+++ b/src/main/features/da/controller/da-addcollaborator.ts
@@ -35,7 +35,7 @@ export const DA_GET_ADD_COLLABORATOR = async (req: express.Request, res: express
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/da/controller/da-leadProcurement.ts
+++ b/src/main/features/da/controller/da-leadProcurement.ts
@@ -31,7 +31,7 @@ export const DA_GET_LEAD_PROCUREMENT = async (req: express.Request, res: express
     const usersRaw = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/eoi/controller/addcollaborator.ts
+++ b/src/main/features/eoi/controller/addcollaborator.ts
@@ -38,7 +38,7 @@ export const GET_ADD_COLLABORATOR = async (req: express.Request, res: express.Re
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/eoi/controller/leadProcurement.ts
+++ b/src/main/features/eoi/controller/leadProcurement.ts
@@ -33,7 +33,7 @@ export const GET_LEAD_PROCUREMENT = async (req: express.Request, res: express.Re
     const usersRaw = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/fca/controller/addcollaborator.ts
+++ b/src/main/features/fca/controller/addcollaborator.ts
@@ -31,7 +31,7 @@ export const GET_ADD_COLLABORATOR = async (req: express.Request, res: express.Re
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop?.data ?? {};

--- a/src/main/features/fca/controller/leadProcurement.ts
+++ b/src/main/features/fca/controller/leadProcurement.ts
@@ -25,7 +25,7 @@ export const GET_LEAD_PROCUREMENT = async (req: express.Request, res: express.Re
     const usersRaw = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/g-cloud/controller/addcollaborator.ts
+++ b/src/main/features/g-cloud/controller/addcollaborator.ts
@@ -34,7 +34,7 @@ export const GET_ADD_COLLABORATOR = async (req: express.Request, res: express.Re
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/requirements/controller/ca-addcollaborator.ts
+++ b/src/main/features/requirements/controller/ca-addcollaborator.ts
@@ -30,7 +30,7 @@ export const CA_GET_ADD_COLLABORATOR = async (req: express.Request, res: express
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/requirements/controller/ca-leadProcurement.ts
+++ b/src/main/features/requirements/controller/ca-leadProcurement.ts
@@ -26,7 +26,7 @@ export const CA_GET_LEAD_PROCUREMENT = async (req: express.Request, res: express
     const usersRaw = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/requirements/controller/ca-review.ts
+++ b/src/main/features/requirements/controller/ca-review.ts
@@ -56,7 +56,7 @@ export const CA_GET_review = async (req: express.Request, res: express.Response)
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/requirements/controller/da-addcollaborator.ts
+++ b/src/main/features/requirements/controller/da-addcollaborator.ts
@@ -31,7 +31,7 @@ export const DA_GET_ADD_COLLABORATOR = async (req: express.Request, res: express
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/requirements/controller/da-leadProcurement.ts
+++ b/src/main/features/requirements/controller/da-leadProcurement.ts
@@ -26,7 +26,7 @@ export const DA_GET_LEAD_PROCUREMENT = async (req: express.Request, res: express
     const usersRaw = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/requirements/controller/rfp-addcollaborator.ts
+++ b/src/main/features/requirements/controller/rfp-addcollaborator.ts
@@ -39,7 +39,7 @@ export const RFP_GET_ADD_COLLABORATOR = async (req: express.Request, res: expres
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/requirements/controller/rfp-leadProcurement.ts
+++ b/src/main/features/requirements/controller/rfp-leadProcurement.ts
@@ -33,7 +33,7 @@ export const RFP_GET_LEAD_PROCUREMENT = async (req: express.Request, res: expres
     const usersRaw = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/rfi/controller/addcollaborator.ts
+++ b/src/main/features/rfi/controller/addcollaborator.ts
@@ -37,7 +37,7 @@ export const GET_ADD_COLLABORATOR = async (req: express.Request, res: express.Re
     const allUserStorge = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/features/rfi/controller/leadProcurement.ts
+++ b/src/main/features/rfi/controller/leadProcurement.ts
@@ -34,7 +34,7 @@ export const GET_LEAD_PROCUREMENT = async (req: express.Request, res: express.Re
     const usersRaw = [];
     for (let a = 1; a <= pageCount; a++) {
       const organisation_user_data_loop = (
-        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], { currentPage: a })
+        await ppg.api.organisation.getOrganisationUsers(req.session?.['organizationId'], a)
       ).unwrap();
 
       const { userList } = organisation_user_data_loop ?? {};

--- a/src/main/services/gCloud/search/api.ts
+++ b/src/main/services/gCloud/search/api.ts
@@ -2,6 +2,7 @@ import { genericFecthGet } from 'main/services/helpers/api';
 import { EndPoints, GCloudServiceAggregations, GCloudServiceSearch } from 'main/services/types/gCloud/search/api';
 import { FetchResult } from 'main/services/types/helpers/api';
 import { baseURL } from './helpers';
+import { QueryParams } from 'main/services/types/helpers/url';
 
 const headers = () => ({
   'Content-Type': 'application/json',
@@ -13,7 +14,7 @@ const endPointWithIndex = (path: string) => {
 };
 
 // GET /:g-cloud-index/services/search
-const getServicesSearch = async (queryParams?: { [key: string]: string }): Promise<FetchResult<GCloudServiceSearch>> => {
+const getServicesSearch = async (queryParams?: QueryParams): Promise<FetchResult<GCloudServiceSearch>> => {
   return genericFecthGet<GCloudServiceSearch>(
     {
       baseURL: baseURL(),
@@ -25,7 +26,7 @@ const getServicesSearch = async (queryParams?: { [key: string]: string }): Promi
 };
 
 // GET /:g-cloud-index/services/aggregations
-const getServicesAggregations = async (queryParams?: { [key: string]: string }): Promise<FetchResult<GCloudServiceAggregations>> => {
+const getServicesAggregations = async (queryParams?: QueryParams): Promise<FetchResult<GCloudServiceAggregations>> => {
   return genericFecthGet<GCloudServiceAggregations>(
     {
       baseURL: baseURL(),

--- a/src/main/services/publicProcurementGateway/organisation/api.ts
+++ b/src/main/services/publicProcurementGateway/organisation/api.ts
@@ -10,20 +10,21 @@ const headers = () => ({
 });
 
 // GET /organisation-profiles/:organisation-id
-const getOrganisation = async (organisationId: string, queryParams?: { [key: string]: string }): Promise<FetchResult<Organisation>> => {
+const getOrganisation = async (organisationId: string): Promise<FetchResult<Organisation>> => {
   return genericFecthGet<Organisation>(
     {
       baseURL: baseURL(),
       path: EndPoints.ORGANISATION,
       params: { organisationId },
-      queryParams: queryParams
     },
     headers()
   );
 };
 
 // GET /organisation-profiles/:organisation-id/users
-const getOrganisationUsers = async (organisationId: string, queryParams?: { [key: string]: string }): Promise<FetchResult<OrganisationUsers>> => {
+const getOrganisationUsers = async (organisationId: string, currentPage?: number): Promise<FetchResult<OrganisationUsers>> => {
+  const queryParams = currentPage !== undefined ? { currentPage: String(currentPage) } : undefined;
+
   return genericFecthGet<OrganisationUsers>(
     {
       baseURL: baseURL(),
@@ -36,14 +37,13 @@ const getOrganisationUsers = async (organisationId: string, queryParams?: { [key
 };
 
 // GET /user-profiles
-const getUserProfiles = async (userId: string, queryParams?: { [key: string]: string }): Promise<FetchResult<UserProfile>> => {
+const getUserProfiles = async (userId: string): Promise<FetchResult<UserProfile>> => {
   return genericFecthGet<UserProfile>(
     {
       baseURL: baseURL(),
       path: EndPoints.USER_PROFILES,
       queryParams: {
         'user-Id': userId,
-        ...queryParams
       }
     },
     headers()

--- a/src/main/services/tendersService/projects/api.ts
+++ b/src/main/services/tendersService/projects/api.ts
@@ -3,9 +3,10 @@ import { FetchResult } from 'main/services/types/helpers/api';
 import { baseURL, headers } from '../helpers';
 import { EndPoints } from 'main/services/types/tendersService/projects/api';
 import { Project } from '@common/middlewares/models/tendersService/project';
+import { QueryParams } from 'main/services/types/helpers/url';
 
 // GET /tenders/projects
-const getProjects = async (accessToken: string, queryParams?: { [key: string]: string }): Promise<FetchResult<Project[]>> => {
+const getProjects = async (accessToken: string, queryParams?: QueryParams): Promise<FetchResult<Project[]>> => {
   return genericFecthGet<Project[]>(
     {
       baseURL: baseURL(),

--- a/src/main/services/types/helpers/url.ts
+++ b/src/main/services/types/helpers/url.ts
@@ -1,14 +1,16 @@
+type QueryParams = string | string[][] | Record<string, string> | URLSearchParams
+
 type FormatURLParams = {
   baseURL: string
   path: string
   params?: { [key: string]: string }
-  queryParams?: { [key: string]: string }
+  queryParams?: QueryParams
 }
 
 type FormatRelativeURLParams = {
   path: string
   params?: { [key: string]: string }
-  queryParams?: { [key: string]: string }
+  queryParams?: QueryParams
 }
 
-export { FormatURLParams, FormatRelativeURLParams };
+export { QueryParams, FormatURLParams, FormatRelativeURLParams };

--- a/src/spec/services/helpers/url.spec.ts
+++ b/src/spec/services/helpers/url.spec.ts
@@ -23,14 +23,34 @@ describe('URL helpers', () => {
       expect(formatURL({ baseURL, path, params: { userId: 'user-1234' } })).to.eq('http://example.com/test/:testId/user/user-1234');
     });
 
-    it('adds the query parameters', () => {
-      const path = '/test';
-      const queryParams = {
-        test: 'test',
-        myParam: 'myParam'
-      };
+    describe('when considering query params', () => {
+      it('adds the query parameters when the params are a string', () => {
+        const path = '/test';
+        const queryParams = 'test=test&myParam';
 
-      expect(formatURL({ baseURL, path, queryParams })).to.eq('http://example.com/test?test=test&myParam=myParam');
+        expect(formatURL({ baseURL, path, queryParams })).to.eq('http://example.com/test?test=test&myParam=');
+      });
+
+      it('adds the query parameters when the params are a record', () => {
+        const path = '/test';
+        const queryParams = {
+          test: 'test',
+          myParam: 'myParam'
+        };
+  
+        expect(formatURL({ baseURL, path, queryParams })).to.eq('http://example.com/test?test=test&myParam=myParam');
+      });
+
+      it('adds the query parameters when the params are an array of array', () => {
+        const path = '/test';
+        const queryParams = [
+          ['test', 'test'],
+          ['myParam', 'myParam'],
+          ['myParam', 'myOtherParam']
+        ];
+
+        expect(formatURL({ baseURL, path, queryParams })).to.eq('http://example.com/test?test=test&myParam=myParam&myParam=myOtherParam');
+      });
     });
 
     it('works when all params are passed', () => {
@@ -71,6 +91,36 @@ describe('URL helpers', () => {
       };
 
       expect(formatRelativeURL({ path, queryParams })).to.eq('/test?test=test&myParam=myParam');
+    });
+
+    describe('when considering query params', () => {
+      it('adds the query parameters when the params are a string', () => {
+        const path = '/test';
+        const queryParams = 'test=test&myParam';
+
+        expect(formatRelativeURL({ path, queryParams })).to.eq('/test?test=test&myParam=');
+      });
+
+      it('adds the query parameters when the params are a record', () => {
+        const path = '/test';
+        const queryParams = {
+          test: 'test',
+          myParam: 'myParam'
+        };
+  
+        expect(formatRelativeURL({ path, queryParams })).to.eq('/test?test=test&myParam=myParam');
+      });
+
+      it('adds the query parameters when the params are an array of array', () => {
+        const path = '/test';
+        const queryParams = [
+          ['test', 'test'],
+          ['myParam', 'myParam'],
+          ['myParam', 'myOtherParam']
+        ];
+
+        expect(formatRelativeURL({ path, queryParams })).to.eq('/test?test=test&myParam=myParam&myParam=myOtherParam');
+      });
     });
 
     it('works when all params are passed', () => {

--- a/src/spec/services/publicProcurementGateway/organisation/api.spec.ts
+++ b/src/spec/services/publicProcurementGateway/organisation/api.spec.ts
@@ -18,12 +18,7 @@ describe('Organisation API helpers', () => {
   const restHandlers = [
     rest.get(`${baseURL}/organisation-profiles/${orgId}`, (req, res, ctx) => {
       if (matchHeaders(req, headers)) {
-        if(matchQueryParams(req, '')) {
-          return res(ctx.status(200), ctx.json({ identifier: { legalName: 'myOrgNoParam' } }));
-        }
-        if (matchQueryParams(req, '?my_param=myParam')) {
-          return res(ctx.status(200), ctx.json({ identifier: { legalName: 'myOrg' } }));
-        }
+        return res(ctx.status(200), ctx.json({ identifier: { legalName: 'myOrgNoParam' } }));
       }
 
       return res(ctx.status(400));
@@ -33,7 +28,7 @@ describe('Organisation API helpers', () => {
         if(matchQueryParams(req, '')) {
           return res(ctx.status(200), ctx.json({ pageCount: 1, userList: [{ userName: 'myUsernameNoParam', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }] }));
         }
-        if (matchQueryParams(req, '?my_param=myParam')) {
+        if (matchQueryParams(req, '?currentPage=12')) {
           return res(ctx.status(200), ctx.json({ pageCount: 1, userList: [{ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }] }));
         }
       }
@@ -42,12 +37,7 @@ describe('Organisation API helpers', () => {
     }),
     rest.get(`${baseURL}/user-profiles`, (req, res, ctx) => {
       if (matchHeaders(req, headers)) {
-        if(matchQueryParams(req, `?user-Id=${userId}`)) {
-          return res(ctx.status(200), ctx.json({ userName: 'myUsernameNoParam', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }));
-        }
-        if (matchQueryParams(req, `?user-Id=${userId}&my_param=myParam`)) {
-          return res(ctx.status(200), ctx.json({ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }));
-        }
+        return res(ctx.status(200), ctx.json({ userName: 'myUsernameNoParam', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }));
       }
 
       return res(ctx.status(400));
@@ -69,13 +59,6 @@ describe('Organisation API helpers', () => {
       expect(findOrganisationResult.status).to.eq(FetchResultStatus.OK);
       expect(findOrganisationResult.data).to.eql({ identifier: { legalName: 'myOrgNoParam' } });
     });
-
-    it('calls the get organisation endpoint with the correct url, headers and query params', async () => {
-      const findOrganisationResult = await organisationAPI.getOrganisation(orgId, { my_param: 'myParam' }) as FetchResultOK<Organisation>;
-
-      expect(findOrganisationResult.status).to.eq(FetchResultStatus.OK);
-      expect(findOrganisationResult.data).to.eql({ identifier: { legalName: 'myOrg' } });
-    });
   });
 
   describe('getOrganisationUsers', () => {
@@ -87,7 +70,7 @@ describe('Organisation API helpers', () => {
     });
 
     it('calls the get organisation users endpoint with the correct url, headers and query params', async () => {
-      const getOrganisationUsersResult = await organisationAPI.getOrganisationUsers(orgId, { my_param: 'myParam' }) as FetchResultOK<OrganisationUsers>;
+      const getOrganisationUsersResult = await organisationAPI.getOrganisationUsers(orgId, 12) as FetchResultOK<OrganisationUsers>;
 
       expect(getOrganisationUsersResult.status).to.eq(FetchResultStatus.OK);
       expect(getOrganisationUsersResult.data).to.eql({ pageCount: 1, userList: [{ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' }] });
@@ -100,13 +83,6 @@ describe('Organisation API helpers', () => {
 
       expect(findUserProfileResult.status).to.eq(FetchResultStatus.OK);
       expect(findUserProfileResult.data).to.eql({ userName: 'myUsernameNoParam', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' });
-    });
-
-    it('calls the get user profile endpoint with the correct url, headers and query params', async () => {
-      const findUserProfileResult = await organisationAPI.getUserProfiles(userId, { my_param: 'myParam' }) as FetchResultOK<UserProfile>;
-
-      expect(findUserProfileResult.status).to.eq(FetchResultStatus.OK);
-      expect(findUserProfileResult.data).to.eql({ userName: 'myUsername', firstName: 'myFirstName', lastName: 'myLastName', telephone: 'myTelephone' });
     });
   });
 });


### PR DESCRIPTION
### JIRA link

Linked to [CAS-1609](https://crowncommercialservice.atlassian.net/browse/CAS-1609)

### Change description

While trying to make use of the g-cloud API services I found that the current type we used for params was not broad enough. Specifically, we could not pass query params with an array value.

As query params get passed as the argument to `URLSearchParams`, I’ve updated the query params type to match what `URLSearchParams` accepts when it is being initialised.

I’ve also made a slight tweak to the ppg organisation API to account for these changes.

### Work checklist

- [x] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


[CAS-1609]: https://crowncommercialservice.atlassian.net/browse/CAS-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ