### PR TITLE
CAS-1701 - Remove `rel="noopener noreferrer"` from links to CCS contact us form

### DIFF
--- a/src/main/features/fca/views/supplier_rate_card.njk
+++ b/src/main/features/fca/views/supplier_rate_card.njk
@@ -104,7 +104,7 @@
 <div class="ccs-callout-panel">
 <h2 class="govuk-heading-m">Help</h2>
 
- <p class="govuk-body">You can contact us by email, phone or using the <a target="_blank" rel="noopener noreferrer" href="https://www.crowncommercial.gov.uk/contact">enquiry form <span class="govuk-visually-hidden">Opens in a new tab</span></a>.</p>
+ <p class="govuk-body">You can contact us by email, phone or using the <a target="_blank" href="https://www.crowncommercial.gov.uk/contact">enquiry form <span class="govuk-visually-hidden">Opens in a new tab</span></a>.</p>
 
 <h3 class="govuk-heading-s govuk-!-margin-0">Telephone: </h3>
  <p class="govuk-body">

--- a/src/main/views/components/helper/macro.njk
+++ b/src/main/views/components/helper/macro.njk
@@ -4,7 +4,7 @@
 			<div class="govuk-grid-column-full">
 				<div class="govuk-inset-text ccs_pre_footer_help">
 					<h2 class="govuk-heading-m">Help</h2>
-					<p class="govuk-body govuk-!-margin-bottom-2">You can contact us by email, phone or using the <a target="_blank" rel="noopener noreferrer" href="https://www.crowncommercial.gov.uk/contact">enquiry form <span class="govuk-visually-hidden">Opens in a new tab</span></a>.</p>
+					<p class="govuk-body govuk-!-margin-bottom-2">You can contact us by email, phone or using the <a target="_blank" href="https://www.crowncommercial.gov.uk/contact">enquiry form <span class="govuk-visually-hidden">Opens in a new tab</span></a>.</p>
 					<p class="govuk-body govuk-!-margin-bottom-0">
 						<strong>Email:</strong>
 					</p>

--- a/src/main/views/components/mcf3helper/macro.njk
+++ b/src/main/views/components/mcf3helper/macro.njk
@@ -4,7 +4,7 @@
         <div class="govuk-grid-column-full">
             <div class="govuk-inset-text ccs_pre_footer_help">
                 <h2 class="govuk-heading-m">Help</h2>
-                <p class="govuk-body govuk-!-margin-bottom-2">You can contact us by email, phone or using the <a target="_blank" rel="noopener noreferrer" href="https://www.crowncommercial.gov.uk/contact">enquiry form <span class="govuk-visually-hidden">Opens in a new tab</span></a>.</p>
+                <p class="govuk-body govuk-!-margin-bottom-2">You can contact us by email, phone or using the <a target="_blank" href="https://www.crowncommercial.gov.uk/contact">enquiry form <span class="govuk-visually-hidden">Opens in a new tab</span></a>.</p>
                 <p class="govuk-body govuk-!-margin-bottom-0">
                     <strong>Email:</strong>
                 </p>

--- a/src/main/views/components/support/macro.njk
+++ b/src/main/views/components/support/macro.njk
@@ -2,7 +2,7 @@
   <div class="ccs-callout-panel">
     <h2 class="govuk-heading-m">Contact</h2>
 
-    <p class="govuk-body">You can contact us by email, phone or using the <a target="_blank" rel="noopener noreferrer" href="https://www.crowncommercial.gov.uk/contact">enquiry form <span class="govuk-visually-hidden">Opens in a new tab</span></a>.</p>
+    <p class="govuk-body">You can contact us by email, phone or using the <a target="_blank" href="https://www.crowncommercial.gov.uk/contact">enquiry form <span class="govuk-visually-hidden">Opens in a new tab</span></a>.</p>
 
     <h3 class="govuk-heading-s govuk-!-margin-0">Telephone: </h3>
     <p class="govuk-body">

--- a/src/main/views/error/401.njk
+++ b/src/main/views/error/401.njk
@@ -6,7 +6,7 @@
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main"> 
     <h1 class="govuk-heading-xl page-title">You are not authorised to view this page</h1>
     <p class="govuk-body">If you need access,
-        <a target="_blank" rel="noreferrer noopener" href="https://www.crowncommercial.gov.uk/contact">contact CCS (opens in a new window)</a> who will be able to provide further support.</p>
+        <a target="_blank" href="https://www.crowncommercial.gov.uk/contact">contact CCS (opens in a new window)</a> who will be able to provide further support.</p>
     <p class="govuk-body">You can also return to the
         <a href="/">homepage</a>.</p>
     </main>  

--- a/src/main/views/error/404.njk
+++ b/src/main/views/error/404.njk
@@ -8,7 +8,7 @@
       <p class="govuk-body">If you typed the web address, check it is correct.</p>
       <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
        <p class="govuk-body">If the web address is correct or you selected a link or button,
-        <a target="_blank" rel="noreferrer noopener" href="https://www.crowncommercial.gov.uk/contact">contact CCS (opens in a new window)</a> who will be able to provide further support.</p>
+        <a target="_blank" href="https://www.crowncommercial.gov.uk/contact">contact CCS (opens in a new window)</a> who will be able to provide further support.</p>
         <p class="govuk-body">You can also return to the
         <a href="/">homepage</a>.</p>
     </main>  

--- a/src/main/views/error/500.njk
+++ b/src/main/views/error/500.njk
@@ -9,7 +9,7 @@
      <h1 class="govuk-heading-xl page-title">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later.</p>
       <p class="govuk-body">
-          <a target="_blank" rel="noreferrer noopener" href="https://www.crowncommercial.gov.uk/contact">contact CCS (opens in a new window)</a> who will be able to provide further support.</p>
+          <a target="_blank" href="https://www.crowncommercial.gov.uk/contact">contact CCS (opens in a new window)</a> who will be able to provide further support.</p>
         <p class="govuk-body">You can also return to the
         <a href="/">homepage</a>.</p>
       </p>


### PR DESCRIPTION
### JIRA link

[CAS-1701](https://crowncommercialservice.atlassian.net/browse/CAS-1701)

### Change description

Remove `rel="noopener noreferrer"` from links to CCS contact us form as they obscure the CAS website in the referrer (or something like that).

### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [ ] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


[CAS-1701]: https://crowncommercialservice.atlassian.net/browse/CAS-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ