### PR TITLE
CAS-1942 Remove GCloud Customer Guidance Link From Related Content

### DIFF
--- a/src/main/resources/content/gcloud/chooseACategory.json
+++ b/src/main/resources/content/gcloud/chooseACategory.json
@@ -25,10 +25,6 @@
     ],
     "related_content": [
       {
-          "text": "G-Cloud 13 customer guidance",
-          "href": "https://assets.crowncommercial.gov.uk/wp-content/uploads/RM1557.13-G-Cloud-13-customer-guidance-v1.0-1.odt"
-      },
-      {
           "text": "G-Cloud 13 agreement page",
           "href": "https://www.crowncommercial.gov.uk/agreements/RM1557.13"
       }

--- a/src/main/resources/content/gcloud/downloadYourSearch.json
+++ b/src/main/resources/content/gcloud/downloadYourSearch.json
@@ -8,10 +8,6 @@
     "buttonText":"Continue",
     "related_content": [
       {
-          "text": "G-Cloud 13 customer guidance",
-          "href": "https://assets.crowncommercial.gov.uk/wp-content/uploads/RM1557.13-G-Cloud-13-customer-guidance-v1.0-1.odt"
-      },
-      {
           "text": "G-Cloud 13 agreement page",
           "href": "https://www.crowncommercial.gov.uk/agreements/RM1557.13"
       }

--- a/src/main/resources/content/gcloud/exportResults.json
+++ b/src/main/resources/content/gcloud/exportResults.json
@@ -17,10 +17,6 @@
     },
     "related_content": [
       {
-          "text": "G-Cloud 13 customer guidance",
-          "href": "https://assets.crowncommercial.gov.uk/wp-content/uploads/RM1557.13-G-Cloud-13-customer-guidance-v1.0-1.odt"
-      },
-      {
           "text": "G-Cloud 13 agreement page",
           "href": "https://www.crowncommercial.gov.uk/agreements/RM1557.13"
       }

--- a/src/main/resources/content/gcloud/newSearch.json
+++ b/src/main/resources/content/gcloud/newSearch.json
@@ -34,10 +34,6 @@
     },
     "related_content": [
       {
-          "text": "G-Cloud 13 customer guidance",
-          "href": "https://assets.crowncommercial.gov.uk/wp-content/uploads/RM1557.13-G-Cloud-13-customer-guidance-v1.0-1.odt"
-      },
-      {
           "text": "G-Cloud 13 agreement page",
           "href": "https://www.crowncommercial.gov.uk/agreements/RM1557.13"
       }

--- a/src/main/resources/content/gcloud/saveYourSearch.json
+++ b/src/main/resources/content/gcloud/saveYourSearch.json
@@ -11,10 +11,6 @@
   ],
   "related_content": [
     {
-        "text": "G-Cloud 13 customer guidance",
-        "href": "https://assets.crowncommercial.gov.uk/wp-content/uploads/RM1557.13-G-Cloud-13-customer-guidance-v1.0-1.odt"
-    },
-    {
         "text": "G-Cloud 13 agreement page",
         "href": "https://www.crowncommercial.gov.uk/agreements/RM1557.13"
     }

--- a/src/main/resources/content/gcloud/savedSearchs.json
+++ b/src/main/resources/content/gcloud/savedSearchs.json
@@ -1,10 +1,7 @@
 {
 
   "related_content": [
-    {
-        "text": "G-Cloud 13 customer guidance",
-        "href": "https://assets.crowncommercial.gov.uk/wp-content/uploads/RM1557.13-G-Cloud-13-customer-guidance-v1.0-1.odt"
-    },
+
     {
         "text": "G-Cloud 13 agreement page",
         "href": "https://www.crowncommercial.gov.uk/agreements/RM1557.13"

--- a/src/main/resources/content/procurement/gcloud-procurement.json
+++ b/src/main/resources/content/procurement/gcloud-procurement.json
@@ -100,10 +100,6 @@
   ],
   "related_content": [
     {
-        "text": "G-Cloud 13 customer guidance",
-        "href": "https://assets.crowncommercial.gov.uk/wp-content/uploads/RM1557.13-G-Cloud-13-customer-guidance-v1.0-1.odt"
-    },
-    {
         "text": "G-Cloud 13 agreement page",
         "href": "https://www.crowncommercial.gov.uk/agreements/RM1557.13"
     }


### PR DESCRIPTION
### JIRA link
[CAS-1942](https://crowncommercialservice.atlassian.net/browse/CAS-1942)

### Change description
Remove 'G-Cloud 13 Customer Guidance' link from right hand panel as it is no longer valid. 


### Work checklist

- [ ] Unit tests added where applicable
- [ ] Route tests added for new pages
- [ ] New pages included in a11y tests
- [ ] Review and publish page updated
- [ ] UI changes look good on mobile

### Developer self-QA run statement

- [] I have clicked through the running application to see if all changes I made actually work.

### Does this PR introduce a breaking change?

- [ ] Yes
- [] No


[CAS-1942]: https://crowncommercialservice.atlassian.net/browse/CAS-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ