### PR TITLE
Use GitHub actions to run tests for CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  workflow_call:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Build
+        uses: docker/build-push-action@v5

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -1,0 +1,29 @@
+name: "Node CI"
+
+on:
+  workflow_call:
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install NPM packages
+        run: npm ci
+
+      - name: Type Check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: "Run our tests"
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  run-unit-tests:
+    uses: ./.github/workflows/mocha.yml
+
+  run-docker-build:
+    uses: ./.github/workflows/docker-image.yml


### PR DESCRIPTION
### JIRA link

N/A

### Change description

As we are going to move away from using Travis for the CI, make use of GitHub actions so that we can continue to test our code

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
