### PR TITLE
CAS-1941 Check Service Levels Percentage is > 0

### DIFF
--- a/src/main/assets/scripts/validations/rfp_service_level_kpis.js
+++ b/src/main/assets/scripts/validations/rfp_service_level_kpis.js
@@ -328,7 +328,7 @@ const emptyFieldCheckRfpKPI = (type_base='') => {
             errorStore.push(fieldCheck);
           }
 
-          if (target_field.value.trim() == '0'){
+          if (Number(target_field.value.trim()) == 0){
             ccsZaddErrorMessage(target_field, 'Success target must be greater than or equal to 1');
             isError = true;
             fieldCheck = ["rfp_term_percentage_KPI_" + x, 'Success target must be greater than or equal to 1'];
@@ -377,7 +377,7 @@ const emptyFieldCheckRfpKPI = (type_base='') => {
               errorStore.push(fieldCheck);
             }
 
-            if (target_field.value.trim() == '0'){
+            if (Number(target_field.value.trim()) == 0){
               ccsZaddErrorMessage(target_field, 'Success target must be greater than or equal to 1');
               isError = true;
               fieldCheck = ["rfp_term_percentage_KPI_" + x, 'Success target must be greater than or equal to 1'];

--- a/src/main/views/components/questions/template.njk
+++ b/src/main/views/components/questions/template.njk
@@ -2302,7 +2302,8 @@
                                 suffix: {
                                   text: "%"
                                 },
-                                type:"number"
+                                type:"number",
+                                min: 1
                                
                               }) }}
 
@@ -2416,7 +2417,8 @@
                                   suffix: {
                                     text: "%"
                                   },
-                                  type:"number"
+                                  type:"number",
+                                  min: 1
                                  
                                 }) }}
               {% endif %}


### PR DESCRIPTION
### JIRA link

[CAS-1941](https://crowncommercialservice.atlassian.net/browse/CAS-1941)

### Change description

Update percentage input field to force number greater than 0.

Min of 1 was only set on first field, but not any extra fields added.

With previous check of "target_field.value.trim() == '0'" allowed values of "00" and "000" 


[CAS-1941]: https://crowncommercialservice.atlassian.net/browse/CAS-1941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ