### PR TITLE
CAS-2003 GCloud Sanitize Search

### DIFF
--- a/src/main/assets/scripts/application.js
+++ b/src/main/assets/scripts/application.js
@@ -2305,33 +2305,34 @@ function getCriterianDetails(totalresult = 0) {
 
   let search = queryParamObj.filter(el => el.key === 'q');
   if (search.length > 0) {
-    criteriaDetails += ' containing <b>' + decodeURIComponent(search[0].value) + '</b>';
+    criteriaDetails += ' containing <b>' + sanitize(decodeURIComponent(search[0].value)) + '</b>';
   }
 
   let lot = queryParamObj.filter(el => el.key === 'lot');
   if (lot.length > 0) {
-    criteriaDetails += ' in <b>' + capitalize(lot[0].value.replace("-", " ")) + '</b>';
+    criteriaDetails += ' in <b>' + sanitize(capitalize(lot[0].value.replace("-", " "))) + '</b>';
   } else {
     criteriaDetails += ' in <b>All Categories</b>';
   }
 
   let serviceCategories = queryParamObj.filter(el => el.key === 'serviceCategories');
   if (serviceCategories.length > 0) {
-    criteriaDetails += ' in the category <b>' + capitalize(serviceCategories[0].value.replace("+", " ")) + '</b>';
+    criteriaDetails += ' in the category <b>' + sanitize(capitalize(serviceCategories[0].value.replace("+", " "))) + '</b>';
   }
 
 
   Object.keys(criteria).forEach(key => {
     if (key !== undefined) {
-      criteriaDetails += ', where <b>' + capitalize(key) + '</b> is ';
+      criteriaDetails += ', where <b>' + sanitize(capitalize(key)) + '</b> is ';
       let values = [];
       for (let index = 0; index < criteria[key].length; index++) {
-        values.push('<b>' + capitalize(criteria[key][index].name) + '</b>');
+        values.push('<b>' + sanitize(capitalize(criteria[key][index].name)) + '</b>');
       }
       criteriaDetails += values.join(" and ");
-
     }
   });
+
+
   $('#criteriandetails').html(criteriaDetails);
   $('#criteriadetailsform').val(criteriaDetails.replace('govuk-!-font-size-48', 'govuk-!-font-size-24'));
 
@@ -2342,6 +2343,11 @@ const capitalize = (s) => {
   if (typeof s !== 'string') return ''
   return s.charAt(0).toUpperCase() + s.slice(1)
 }
+
+const sanitize = (s) => {
+  return s.toLowerCase().includes('<script') ? '': s;
+}
+
 
 
 document.querySelectorAll(".dos_evaluate_supplier").forEach(function (event) {

--- a/src/main/features/g-cloud/controller/search.ts
+++ b/src/main/features/g-cloud/controller/search.ts
@@ -8,10 +8,15 @@ import { gCloud } from 'main/services/gCloud';
 import { formatRelativeURL } from 'main/services/helpers/url';
 import { QueryParams } from 'main/services/types/helpers/url';
 import { GCloudServiceSearch } from 'main/services/types/gCloud/search/api';
+import sanitizeHtml from 'sanitize-html';
 
 export const GET_SEARCH = async (req: Request, res: Response) => {
   const { SESSION_ID } = req.cookies;
-  const { lot, serviceCategories, parentCategory, q } = req.query;
+  let { lot, serviceCategories, parentCategory, q } = req.query;
+
+  // Sanitize Search Query
+  q = sanitizeHtml(q as string);
+
   try {
     const queryParamsForServicesAggregationsAPI = extractQueryParamsForSearchAPI(req.query, QueryParamType.AGGREGATIONS);
 

--- a/src/main/features/g-cloud/util/filter/searchQueryFliter.ts
+++ b/src/main/features/g-cloud/util/filter/searchQueryFliter.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express';
+import sanitizeHtml from 'sanitize-html';
 
 enum QueryParamType {
   AGGREGATIONS,
@@ -24,7 +25,9 @@ const extractQueryParamsForSearchAPI = (query: Request['query'], type: QueryPara
   Object.entries(query).forEach(([key, values]) => {
     if (skipFilter(key, type)) return;
 
-    if (key === 'q'  || key === 'page') {
+    if (key === 'q' ) {
+      queryParams.push([key, sanitizeHtml(values as string)]);
+    } else if (key === 'page') {
       queryParams.push([key, values as string]);
     } else {
       const newKey = `${prefix}${key}`;


### PR DESCRIPTION
### JIRA link

[CAS-2003](https://crowncommercialservice.atlassian.net/browse/CAS-2003)

So GCloud searching is setup completely different to DOS. 

This is a bit of a work around. 

Every time the user searches the client side js will pluck the search query string and lot name from the url. So this couldnt be fixed just using the sanitize-html package as that is only installed server side. 

---

Short of tearing it all down and starting from scratch, this will fix the GCloud search field for now



[CAS-2003]: https://crowncommercialservice.atlassian.net/browse/CAS-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ