### PR TITLE
CAS-2126 Generic Input Sanitation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
                 "moment-timezone": "^0.5.43",
                 "nunjucks": "^3.2.4",
                 "objectFitPolyfill": "^2.3.0",
+                "perfect-express-sanitizer": "^1.0.13",
                 "redis": "^4.6.11",
                 "rollbar": "^2.26.1",
                 "sanitize-html": "^2.11.0",
@@ -11680,6 +11681,20 @@
             "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
             "dev": true
         },
+        "node_modules/perfect-express-sanitizer": {
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/perfect-express-sanitizer/-/perfect-express-sanitizer-1.0.13.tgz",
+            "integrity": "sha512-MnWRqdWNAGrF3Eqk3hj9Qkm+lFWpVISHyP6IdLLG+kcueU+6SXhOny5BdZljy290sBtYo7oryRroHKxs2iJjPg==",
+            "dependencies": {
+                "body-parser": "^1.20.0",
+                "express": "^4.18.1",
+                "sanitize-html": "^2.7.0",
+                "supertest": "^6.2.4"
+            },
+            "engines": {
+                "node": ">4.0"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -13587,7 +13602,6 @@
             "version": "6.3.3",
             "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
             "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
-            "dev": true,
             "dependencies": {
                 "methods": "^1.1.2",
                 "superagent": "^8.0.5"
@@ -13600,7 +13614,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -13612,7 +13625,6 @@
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
             "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -13627,7 +13639,6 @@
             "version": "8.0.9",
             "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
             "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
-            "dev": true,
             "dependencies": {
                 "component-emitter": "^1.3.0",
                 "cookiejar": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "moment-timezone": "^0.5.43",
         "nunjucks": "^3.2.4",
         "objectFitPolyfill": "^2.3.0",
+        "perfect-express-sanitizer": "^1.0.13",
         "redis": "^4.6.11",
         "rollbar": "^2.26.1",
         "sanitize-html": "^2.11.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -21,6 +21,9 @@ import { setupErrorRoutes } from './setup/routes/setupErrorRoutes';
 import { setupFeatureRoutes } from './setup/routes/setupFeatureRoutes';
 import { setupHomeRoutes } from './setup/routes/setupHomeRoutes';
 
+// @ts-ignore -- no types file
+import sanitizer from 'perfect-express-sanitizer';
+
 const logger = Logger.getLogger('app');
 
 logger.info('Initialising the application');
@@ -73,6 +76,15 @@ redisSession()
     app.use(express.static(pathJoin(__dirname, 'public')));
     app.use(cookieParser());
     app.use(fileUpload());
+
+
+    app.use(
+      sanitizer.clean({
+          xss: true,
+          noSql: true,
+          sql: true,
+      })
+    );
 
     new CsrfProtection().enableFor(app);
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,6 +3,7 @@ import config from 'config';
 import favicon from 'serve-favicon';
 import cookieParser from 'cookie-parser';
 import fileUpload from 'express-fileupload';
+import sanitizer from 'perfect-express-sanitizer';
 import { setLocalEnvVariables } from './setup/localEnvironmentVariables';
 import { Express, Logger } from '@hmcts/nodejs-logging';
 import { initNunjucks } from './modules/nunjucks';
@@ -20,9 +21,6 @@ import { redisSession } from './setup/redis/session';
 import { setupErrorRoutes } from './setup/routes/setupErrorRoutes';
 import { setupFeatureRoutes } from './setup/routes/setupFeatureRoutes';
 import { setupHomeRoutes } from './setup/routes/setupHomeRoutes';
-
-// @ts-ignore -- no types file
-import sanitizer from 'perfect-express-sanitizer';
 
 const logger = Logger.getLogger('app');
 

--- a/src/main/types/perfect-express-sanitizer/index.d.ts
+++ b/src/main/types/perfect-express-sanitizer/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'perfect-express-sanitizer';


### PR DESCRIPTION
### JIRA link

[CAS-2126](https://crowncommercialservice.atlassian.net/browse/CAS-2126)

### Change description

Middleware to sanitise all user input passed from the frontend client to node server.

This will cover us most places. 

However it wont solve the GCloud 13 search example. As this is just client side js getting the data from the url, then displaying it on the page. 

[CAS-2126]: https://crowncommercialservice.atlassian.net/browse/CAS-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ