### PR TITLE
Don't Sanitize the Headers as this breaks Gcloud Search

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -81,7 +81,10 @@ redisSession()
           xss: true,
           noSql: true,
           sql: true,
-      })
+      },
+      [],
+      ['body', 'query']
+      )
     );
 
     new CsrfProtection().enableFor(app);


### PR DESCRIPTION
Dont sanitze the headers as this was breaking GCloud search. 

Gcloud search has Content-Type: 'application/json' which was getting stripped out on each request. So instead of return the json update data it was return the whole search page html
