### PR TITLE
CAS-2276 Improve FE Sanitizing

### DIFF
--- a/src/main/assets/scripts/validations/sanitize.js
+++ b/src/main/assets/scripts/validations/sanitize.js
@@ -1,69 +1,67 @@
 document.addEventListener('DOMContentLoaded', () => {
 
-  const inputs = document.getElementsByTagName('input');
-  const textareas = document.getElementsByTagName('textarea');
+    const inputs = document.getElementsByTagName('input');
+    const textareas = document.getElementsByTagName('textarea');
 
-  const all = [...inputs, ...textareas];
+    const all = [...inputs, ...textareas];
 
-  all.forEach((input) => {
-    input.addEventListener('change', (e) => {
-      const value = e.target.value;
-      if (sanitize(value) !== value) {
-        input.value = '';
-      }
+    all.forEach((input) => {
+        input.addEventListener('change', (e) => {
+            const value = e.target.value;
+            input.value = sanitize(value);
+        });
     });
-  });
 
-  function sanitize(str) {
-    function stringToHTML () {
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(str, 'text/html');
-      return doc.body || document.createElement('body');
+    function sanitize(str) {
+        function stringToHTML() {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(str, 'text/html');
+            return doc.body || document.createElement('body');
+        }
+
+
+        function removeScripts(html) {
+            const scripts = html.querySelectorAll('script');
+
+            for (const script of scripts) {
+                script.remove();
+            }
+        }
+
+        function isPossiblyDangerous(name, value) {
+            const val = value.replace(/\s+/g, '').toLowerCase();
+
+            if (['src', 'href', 'xlink:href'].includes(name)) {
+                if (val.includes('javascript:') || val.includes('data:text/html')) return true;
+            }
+            if (name.startsWith('on')) return true;
+        }
+
+        function removeAttributes(elem) {
+            const atts = elem.attributes;
+
+            for (const {name, value} of atts) {
+                if (!isPossiblyDangerous(name, value)) continue;
+                elem.removeAttribute(name);
+            }
+
+        }
+
+        function clean(html) {
+            const nodes = html.children;
+            for (const node of nodes) {
+                removeAttributes(node);
+                clean(node);
+            }
+        }
+
+        const html = stringToHTML();
+
+        removeScripts(html);
+        clean(html);
+
+        return html.textContent;
     }
-
-
-    function removeScripts (html) {
-      const scripts = html.querySelectorAll('script');
-
-      for (const script of scripts) {
-        script.remove();
-      }
-    }
-
-    function isPossiblyDangerous (name, value) {
-      const val = value.replace(/\s+/g, '').toLowerCase();
-
-      if (['src', 'href', 'xlink:href'].includes(name)) {
-        if (val.includes('javascript:') || val.includes('data:text/html')) return true;
-      }
-      if (name.startsWith('on')) return true;
-    }
-
-    function removeAttributes (elem) {
-      const atts = elem.attributes;
-
-      for (const {name, value} of atts) {
-        if (!isPossiblyDangerous(name, value)) continue;
-        elem.removeAttribute(name);
-      }
-
-    }
-
-    function clean (html) {
-      const nodes = html.children;
-      for (const node of nodes) {
-        removeAttributes(node);
-        clean(node);
-      }
-    }
-
-    const html = stringToHTML();
-
-    removeScripts(html);
-    clean(html);
-
-    return html.innerHTML;
-  }
 });
 
 


### PR DESCRIPTION
### JIRA link

[CAS-2276](https://crowncommercialservice.atlassian.net/browse/CAS-2276)

### Change description

Updated frontend sanitising. 

Previously, if text input/area contained '&', '<script>...' etc it would then remove everything from the text block when the user clicks off of the text field. 

This would then cause issues, as the user would usually click the save button straight after typing, so they wouldnt see the text field being cleared.

This has now been updated so that it will only remove the suspect part of the text e.g. '<script>...' and it no longer removes the html entities like '&'.


[CAS-2276]: https://crowncommercialservice.atlassian.net/browse/CAS-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ